### PR TITLE
Appropriate messages are shown when command has nothing to output

### DIFF
--- a/src/commands/analytics/app-versions.ts
+++ b/src/commands/analytics/app-versions.ts
@@ -58,7 +58,11 @@ export default class ShowAppVersionsCommand extends AppCommand {
       const outputArray = listOfVersions.map((version) => [version.versionProperty, String(version.count)]);
       out.table(out.getCommandOutputTableOptions(["Version", "Number Of Devices"]), outputArray);
     } else {
-      out.text((versions) => versions.join(Os.EOL), listOfVersions.map((version) => version.versionProperty));
+      if (listOfVersions.length) {
+        out.list((version) => version, listOfVersions.map((version) => version.versionProperty));
+      } else {
+        out.text(() => "No records found", []);
+      }
     }    
     
     return success();

--- a/src/commands/analytics/log-flow.ts
+++ b/src/commands/analytics/log-flow.ts
@@ -1,6 +1,6 @@
 import { AppCommand, CommandResult, ErrorCodes, failure, hasArg, help, longName, shortName, success} from "../../util/commandline";
 import { MobileCenterClient, models, clientRequest, ClientResponse } from "../../util/apis";
-import { StreamingArrayOutput } from "../../util/interaction";
+import { out, StreamingArrayOutput } from "../../util/interaction";
 import { inspect } from "util";
 import * as _ from "lodash";
 import { DefaultApp } from "../../util/profile";
@@ -40,6 +40,7 @@ export default class ShowLogFlowCommand extends AppCommand {
     streamingOutput.start();
 
     let options: {start: Date} = null;
+    let someLogsWereOutput = false;
     await ContinuousPollingHelper.pollContinuously(async () => {
       try {
         debug ("Loading logs");
@@ -62,8 +63,14 @@ export default class ShowLogFlowCommand extends AppCommand {
         for (const logEntry of filteredLogs) {
           this.showLogEntry(streamingOutput, logEntry);
         }
+        someLogsWereOutput = someLogsWereOutput || filteredLogs.length > 0;
       }
     }, this.showContinuously, ShowLogFlowCommand.delayBetweenRequests, "Loading logs...");
+
+    if (!someLogsWereOutput) {
+      // no logs were shown, notify users that none were received
+      out.text("No log entries received");
+    }
     
     streamingOutput.finish();
 

--- a/src/commands/apps/get-current.ts
+++ b/src/commands/apps/get-current.ts
@@ -5,14 +5,13 @@ import { Profile, DefaultApp, getUser } from "../../util/profile";
 
 @help("Get the application that's set as default for all CLI commands")
 export default class GetCurrentAppCommand extends Command {
-	constructor(args: CommandArgs) {
-		super(args);
-	}
+  constructor(args: CommandArgs) {
+    super(args);
+  }
 
-	async runNoClient(): Promise<CommandResult> {
-		const user = getUser();
-		const currentApp = user.defaultApp ? `${user.defaultApp.ownerName}/${user.defaultApp.appName}` : "";
-		out.text(s => s, currentApp);
-		return success();
-	}
+  async runNoClient(): Promise<CommandResult> {
+    const user = getUser();
+    out.text((defaultApp) => defaultApp ? `${user.defaultApp.ownerName}/${user.defaultApp.appName}` : "No app is currently set as default, use 'mobile-center apps set-current' command", user && user.defaultApp);
+    return success();
+  }
 }

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -32,10 +32,15 @@ export default class AppsListCommand extends Command {
       return failure(ErrorCodes.Exception, "Unknown error when loading apps");
     }
 
-    const defaultApp = getCurrentApp(null);
-    debug(`Current app = ${inspect(defaultApp)}`);
-    const sortedApps = _.sortBy(appsResponse.result, (app) => (app.owner.name + app.name).toLowerCase());
-    out.list((app) => this.formatApp(defaultApp.value, app), sortedApps);
+    const apps = appsResponse.result;
+    if (apps.length) {
+      const defaultApp = getCurrentApp(null);
+      debug(`Current app = ${inspect(defaultApp)}`);
+      const sortedApps = _.sortBy(apps, (app) => (app.owner.name + app.name).toLowerCase());
+      out.list((app) => this.formatApp(defaultApp.value, app), sortedApps);
+    } else {
+      out.text(() => "No apps available", []);
+    }
 
     return success();
   }

--- a/src/commands/apps/set-current.ts
+++ b/src/commands/apps/set-current.ts
@@ -32,6 +32,9 @@ export default class SetCurrentAppCommand extends Command {
     let profile = getUser();
     profile.defaultApp = newDefault;
     profile.save();
+
+    out.text(`${this.appId} is set as current app`);
+
     return success();
   }
 }

--- a/src/commands/build/branches/list.ts
+++ b/src/commands/build/branches/list.ts
@@ -60,7 +60,11 @@ export default class ShowBranchesListBuildStatusCommand extends AppCommand {
     const commits = commitInfoRequestResponse.result;
 
     const buildReportObjects = branchesWithBuilds.map((branch, index) => getBuildReportObject(branch.lastBuild, commits[index], app, portalBaseUrl));
-    reportBuilds(buildReportObjects);
+    if (buildReportObjects.length) {
+      reportBuilds(buildReportObjects);
+    } else {
+      out.text(() => "No branches with builds found", []);
+    }
 
     return success();
   }

--- a/src/commands/crashes/upload-symbols.ts
+++ b/src/commands/crashes/upload-symbols.ts
@@ -71,6 +71,8 @@ export default class UploadSymbols extends AppCommand {
     // upload symbols
     await out.progress("Uploading symbols...", new UploadSymbolsHelper(client, app, debug).uploadSymbolsZip(pathToZipToUpload));
 
+    out.text("Symbols were successfully uploaded");
+
     return success();
   }
 

--- a/src/commands/distribute/releases/list.ts
+++ b/src/commands/distribute/releases/list.ts
@@ -24,12 +24,16 @@ export default class ShowReleasesCommand extends AppCommand {
       return failure(ErrorCodes.Exception, "failed to get list of releases for the application");
     }
 
-    out.reportNewLineSeparatedArray([
-        ["ID", "id"],
-        ["Short Version", "shortVersion"],
-        ["Version", "version"],
-        ["Uploaded At", "uploadedAt", out.report.asDate]
-      ], releases);
+    if (releases.length) {
+      out.reportNewLineSeparatedArray([
+          ["ID", "id"],
+          ["Short Version", "shortVersion"],
+          ["Version", "version"],
+          ["Uploaded At", "uploadedAt", out.report.asDate]
+        ], releases);
+    } else {
+      out.text(() => "No releases found", []);
+    }
    
     return success();
   }

--- a/src/util/commandline/help.ts
+++ b/src/util/commandline/help.ts
@@ -4,6 +4,7 @@ import * as _ from "lodash";
 import * as os from "os";
 import { isatty } from "tty";
 import { inspect } from "util";
+import * as chalk from "chalk";
 
 const debug = require("debug")("mobile-center-cli:util:commandline:help");
 
@@ -22,22 +23,23 @@ import { out, padLeft, padRight, setDebug } from "../interaction";
 
 import { scriptName } from "../misc";
 
+const usageConst = "Usage: ";
+
 export function runHelp(commandPrototype: any, commandObj: any): void {
   const commandExample: string = getCommandExample(commandPrototype, commandObj);
   const commandHelp: string = getCommandHelp(commandObj);
   const optionsHelpTable: any = getOptionsHelpTable(commandPrototype);
 
   out.help();
-  out.help(commandExample);
-  out.help();
   out.help(commandHelp);
+  out.help();
+  out.help(usageConst + chalk.bold(commandExample));
 
-  if(optionsHelpTable.length > 0) {
+  if (optionsHelpTable.length > 0) {
     out.help();
-    out.help("Command Options:");
+    out.help("Options:");
     out.help(optionsHelpTable.toString());
   }
-  out.help();
 }
 
 function hasOptions(obj: any): boolean {
@@ -68,7 +70,7 @@ function toSwitchOptionHelp(option: OptionDescription): SwitchOptionHelp {
 function getOptionsHelpTable(commandPrototype: any): any {
   const switchOpts = getSwitchOptionsHelp(commandPrototype);
   const posOpts = getPositionalOptionsHelp(commandPrototype);
-  const opts = switchOpts.concat(posOpts);
+  const opts = styleOptsTable(switchOpts.concat(posOpts));
 
   // Calculate max length of the strings from the first column (switches/positional parameters) - it will be a width for the first column;
   const firstColumnWidth = opts.reduce((contenderMaxWidth, optRow) => Math.max(optRow[0].length, contenderMaxWidth), 0);
@@ -81,8 +83,7 @@ function getOptionsHelpTable(commandPrototype: any): any {
 }
 
 function getSwitchOptionsHelp(commandPrototype: any): string[][] {
-  // options from a top prototype are added first, reversing order
-  const options = _(getOptionsDescription(commandPrototype)).values().map(toSwitchOptionHelp).reverse().value();
+  const options = sortOptionDescriptions(_.values(getOptionsDescription(commandPrototype))).map(toSwitchOptionHelp);
   debug(`Command has ${options.length} switch options:`);
   debug(options.map(o => `${o.shortName}|${o.longName}`).join("/"));
   return options.map((optionHelp) => [`    ${switchText(optionHelp)}    `, optionHelp.helpText]);
@@ -137,17 +138,22 @@ function terminalWidth(): number {
 }
 
 function getCommandExample(commandPrototype: any, commandObj: any): string {
-  let commandName = getCommandName(commandObj);
-  let lines: string[] = [];
-  let currentLine = `    ${scriptName} ${commandName}`;
+  const commandName = getCommandName(commandObj);
+  const lines: string[] = [];
+  const lastLinesLeftMargin = "  "; // 2 spaces
+  const linesSeparator = os.EOL + lastLinesLeftMargin;
+  let currentLine = `${scriptName} ${commandName}`;
 
-  let maxWidth = terminalWidth();
-  let rightMargin = 4;
+  const maxWidth = terminalWidth();
+  const separatorLength = os.EOL.length;
+  const firstLineFreeSpace = maxWidth - usageConst.length - separatorLength;
+  const freeSpace = firstLineFreeSpace - lastLinesLeftMargin.length;
+  const leftMargin = _.repeat(" ", usageConst.length);
   getAllOptionExamples(commandPrototype)
     .forEach((example) => {
-      if (currentLine.length + example.length + 1 > maxWidth - rightMargin) {
+      if (currentLine.length + example.length + 1 > (lines.length ? freeSpace : firstLineFreeSpace)) {
         lines.push(currentLine);
-        currentLine = `        ${example}`;
+        currentLine = leftMargin + example;
       } else {
         currentLine += ` ${example}`;
       }
@@ -155,7 +161,7 @@ function getCommandExample(commandPrototype: any, commandObj: any): string {
 
   lines.push(currentLine);
 
-  return lines.join(os.EOL);
+  return lines.join(linesSeparator);
 }
 
 function getCommandName(commandObj: any): string {
@@ -178,7 +184,7 @@ function getAllOptionExamples(commandPrototype: any): string[] {
 function getSwitchOptionExamples(commandPrototype: any): string[] {
   const switchOptions = getOptionsDescription(commandPrototype);
 
-  return _.values(switchOptions)
+  return sortOptionDescriptions(_.values(switchOptions))    
     .map((description: OptionDescription): string => {
       let result: string[] = [];
       result.push(description.shortName ? `-${description.shortName}` : "");
@@ -204,4 +210,19 @@ function getPositionalOptionExamples(commandPrototype: any): string[] {
       // Output for "rest" parameter. sortBy will push it to the end.
       return `<${description.name}...>`;
     });
+}
+
+function styleOptsTable(table: string[][]): string[][] {
+  return table.map((row) => [chalk.bold(row[0])].concat(row.slice(1)));
+}
+
+function sortOptionDescriptions(options: OptionDescription[]): OptionDescription[] {
+  return _(options)
+    .reverse() // options from a top prototype are added first, reversing order
+    .sortBy([(opt: OptionDescription) => opt.required ? 0 : 1]) // required options should be shown first
+    .value();
+}
+
+function highlightString(stringToStyle: string): string {
+  return chalk.bold(stringToStyle);
 }

--- a/src/util/interaction/out.ts
+++ b/src/util/interaction/out.ts
@@ -131,7 +131,7 @@ export function getCommandOutputTableOptions(header: string[]): object {
     head: header, 
     style: { 
       head: [] 
-    } 
+    }
   };
 }
 
@@ -149,8 +149,8 @@ export function getOptionsForTwoColumnTableWithNoBorders(firstColumnWidth: numbe
     chars: {
       "top": "", "top-mid": "", "top-left": "", "top-right": "",
       "bottom": "", "bottom-mid": "", "bottom-left": "", "bottom-right": "",
-      "left": "", "left-mid": "", "mid": " ", "mid-mid": "",
-      "right": "", "right-mid": "", "middle": " "
+      "left": "", "left-mid": "", "mid": "", "mid-mid": "",
+      "right": "", "right-mid": "", "middle": ""
     },
     style: { "padding-left": 0, "padding-right": 0 },
     colWidths: [firstColumnWidth, secondColumnWidth],
@@ -543,11 +543,11 @@ function calculateTableCellsMaxWidthAcrossLevels(wholeTable: INamedTable): Map<s
       } else {
         // inner table
         calculate(entry, level + 1, levelAndCellIndexToMaxWidth);
-      }
     }
+  }
 
     return levelAndCellIndexToMaxWidth;
-  }
+    }
   return calculate(wholeTable, 0, new Map<string, number>());
 }
 
@@ -564,13 +564,13 @@ function padTableCells(wholeTable: INamedTable): INamedTable {
       } else { 
         // inner table
         return pad(entry, level + 1);
-      }
+  }
     });
 
-    return {
-      name: table.name,
+  return {
+    name: table.name,
       content: paddedContent
-    };
+  };
   }
 
   return pad(wholeTable, 0);
@@ -605,8 +605,8 @@ function isINamedTable(object: any): object is INamedTable {
 // number - level of the table (controls left padding of the table and name)
 export type NamedTables = INamedTable[];
 type ObjectToNamedTablesConvertor<T> = (object: T, 
-                                        numberFormatter: (num: number) => string,
-                                        dateFormatter: (date: Date) => string,
+                                numberFormatter: (num: number) => string,
+                                dateFormatter: (date: Date) => string,
                                         percentageFormatter: (percentage: number) => string) => NamedTables;
 
 export function reportObjectAsTitledTables<T>(toNamedTables: ObjectToNamedTablesConvertor<T>, object: T) {


### PR DESCRIPTION
analytics app-versions:
![app-versions-empty](https://user-images.githubusercontent.com/25530829/27612964-b681e484-5ba1-11e7-97c3-b971cce390ae.PNG)
analytics log-flow:
![log-flow-empty](https://user-images.githubusercontent.com/25530829/27612971-bed1082c-5ba1-11e7-90dd-f5763029f6b9.PNG)
apps get-current:
![get-current-empty](https://user-images.githubusercontent.com/25530829/27612981-cfb14ad0-5ba1-11e7-928f-9f054fd3c57a.PNG)
apps list:
![apps-list-empty](https://user-images.githubusercontent.com/25530829/27612991-d5a92d5e-5ba1-11e7-8d1d-91e6e921eab9.PNG)
build branches list:
![build-branches-list-empty](https://user-images.githubusercontent.com/25530829/27613003-e85c5f0c-5ba1-11e7-849e-4dc5036811d0.PNG)
distribute releases list:
![distribute-releases-list-empty](https://user-images.githubusercontent.com/25530829/27613019-fb2dd5c0-5ba1-11e7-87a0-a7484ecee9b7.PNG)

The following commands now also show messages when they finish:
apps set-current:
![apps-set-current](https://user-images.githubusercontent.com/25530829/27613047-1c1726a6-5ba2-11e7-92fd-56969bbd69e8.PNG)
crashes upload-symbols:
![crashes-upload-symbols](https://user-images.githubusercontent.com/25530829/27613057-23ae4714-5ba2-11e7-9487-2ac85353d6c8.PNG)
apps get-current:
![apps-get-current-empty](https://user-images.githubusercontent.com/25530829/27641662-2e9dd8fa-5c25-11e7-9eaf-38e65b4466dd.PNG)


Based on #245 


