### PR TITLE
Fix generated/appCenterClient filename casing

### DIFF
--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -3,7 +3,7 @@ const debug = require("debug")("appcenter-cli:util:apis:create-client");
 import { inspect } from "util";
 import { IncomingMessage } from "http";
 
-import AppCenterClient = require("./generated/AppCenterClient");
+import AppCenterClient = require("./generated/appCenterClient");
 import { AppCenterClientCredentials } from "./appcenter-client-credentials";
 import { userAgentFilter } from "./user-agent-filter";
 import { telemetryFilter } from "./telemetry-filter";


### PR DESCRIPTION
Without this change appcenter cli crashes on case sensitive filesyetems with:

```
kamstrup@mandrill:~$ appcenter 
module.js:538
    throw err;
    ^

Error: Cannot find module './generated/AppCenterClient'
    at Function.Module._resolveFilename (module.js:536:15)
    at Function.Module._load (module.js:466:25)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/lib/node_modules/appcenter-cli/dist/util/apis/create-client.js:6:25)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
```