### PR TITLE
[codepush] fix for cordova-release command

### DIFF
--- a/src/commands/codepush/lib/update-contents-tasks/zip.ts
+++ b/src/commands/codepush/lib/update-contents-tasks/zip.ts
@@ -30,7 +30,7 @@ export default function zip(updateContentsPath: string): Promise<string> {
       const relativePath: string = path.relative(baseDirectoryPath, filePath);
       releaseFiles.push({
         sourceLocation: filePath,
-        targetLocation: normalizePath(changeTmpFolderName(relativePath))
+        targetLocation: normalizePath(relativePath)
       });
     });
 
@@ -53,11 +53,4 @@ export default function zip(updateContentsPath: string): Promise<string> {
 
     zipFile.end();
   });
-}
-
-// we have to change tmp forlder name to make update contents file structure 
-// to be compatibale with client SDKs
-function changeTmpFolderName(relativePath: string) {
-  const tempFolderName = path.dirname(relativePath).split(path.sep)[0];
-  return relativePath.replace(tempFolderName, "CodePush");
 }

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -3,6 +3,7 @@ import CodePushReleaseCommandSkeleton from "./lib/release-command-skeleton"
 import { AppCenterClient, models, clientRequest } from "../../util/apis";
 import { out } from "../../util/interaction";
 import { inspect } from "util";
+import * as fs from "fs";
 import * as pfs from "../../util/misc/promisfied-fs";
 import * as chalk from "chalk";
 import * as path from "path";
@@ -85,6 +86,10 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
     this.platform = appInfo.platform.toLowerCase();
 
     this.updateContentsPath = this.outputDir || await pfs.mkTempDir("code-push");
+    
+    // we have to add "CodePush" root forlder to make update contents file structure 
+    // to be compatible with React Native client SDK
+    fs.mkdirSync(path.join(this.updateContentsPath, "CodePush"));
 
     if (!isValidOS(this.os)) {
       return failure(ErrorCodes.InvalidParameter, `OS must be "android", "ios", or "windows".`);


### PR DESCRIPTION
Update/Release for Cordova has another structure than React updates:
1. Cordova update should contain www/ root folder inside the archive
2. React update should contain CodePush/ root folder inside the archive