### PR TITLE
Test cloud error message improvements

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -154,7 +154,7 @@ export abstract class RunTestsCommand extends AppCommand {
       let message : string = null;
       let profile = getUser();
 
-      let helpMessage = `Further error details: For help, please send the following information to us by going to https://mobile.azure.com/apps and starting a new conversation (using the icon in the bottom right corner of the screen)${os.EOL}
+      let helpMessage = `Further error details: For help, please send both the reported error above and the following environment information to us by going to https://mobile.azure.com/apps and starting a new conversation (using the icon in the bottom right corner of the screen)${os.EOL}
         Environment: ${os.platform()}${os.EOL}
         User Email: ${profile.email}${os.EOL}
         User Name: ${profile.userName}${os.EOL}

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -52,10 +52,77 @@ export class UITestPreparer {
     let exitCode = await process.execAndWait(command, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
-      throw new TestCloudError(`Cannot prepare UI Test artifacts using command: ${command}. Returning exit code ${exitCode}.`, exitCode);
+      let message = this.convertErrorCode(exitCode);
+      throw new TestCloudError(`Cannot prepare UI Test artifacts using command: ${command}.${os.EOL}${os.EOL}${message}`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");
+  }
+
+  private convertErrorCode(exitCode: number): string {
+    let tryAgain = `, please try again. If you can't work out how to fix this issue, please contact support.`;
+
+    switch (exitCode) {
+      case 1:
+        return `There was an unknown error preparing test artifacts,${tryAgain}`;
+      case 2:
+        return `Invalid options were used to prepare the test artifacts${tryAgain}`;
+      case 3:
+        return `The app file was not found${tryAgain}`;
+      case 4:
+        return `The assembly directory was not found${tryAgain}`;
+      case 5:
+        return `The NUnit library was not found${tryAgain}`;
+      case 6:
+        return `The UITest.dll was not found${tryAgain}`;
+      case 7:
+        return `No test assemblies were found${tryAgain}`;
+      case 8:
+        return `The Sign Info File was not found${tryAgain}`;
+      case 9:
+        return `The KeyStore was not found${tryAgain}`;
+      case 10:
+        return `The dSym was not found or was not a directory${tryAgain}`;
+      case 11:
+        return `The dSym directory has the wrong extension${tryAgain}`;
+      case 12:
+        return `The dSym file contains more than one dwarf${tryAgain}`;
+      case 13:
+        return `Test chunking failed${tryAgain}`;
+      case 14:
+        return `Upload negotiation failed${tryAgain}`;
+      case 15:
+        return `The upload failed${tryAgain}`;
+      case 16:
+        return `Job status retrival failed while preparing test artifacts${tryAgain}`;
+      case 17:
+        return `The NUnit report was not returned${tryAgain}`;
+      case 18:
+        return `The job failed while preparing test artifacts${tryAgain}`;
+      case 19:
+        return `There were test failures.`;
+      case 20:
+        return `The version of UITest.dll and the tools are incompatible. ` +
+          `Please make sure --uitest-tools-dir points to the same version of UITest as the dll in your assembly directory.`;
+      case 21:
+        return `No tests would run given the current parameters${tryAgain}`;
+      case 22:
+        return `A specified data file was outside the assembly directory. ` +
+          `Please make sure all referenced data files exist within your assembly directory and try again.`;
+      case 23:
+        return `A specified data file was not found, please check your data files exist and try again. ` +
+        `If this error happens again, please contact support.`;
+      case 24:
+        return `The test run did not pass validation${tryAgain}`;
+      case 25:
+        return `The test run was cancelled.`;
+      case 26:
+        return `The referenced version of NUnit was unsupported, please use NUnit 2.6.4 or below.`;
+      case 27:
+        return `The artifacts directory was invalid${tryAgain}`;
+    }
+
+    return `Returning exit code ${exitCode}.`;
   }
 
   private validateArguments() {


### PR DESCRIPTION
### Motivation
Users have been sending just the environment message, so to help support we should explicitly ask for both the environment message and the error message before hand.

### Changes

- Slight alteration to blanket error message to ask for both env message and error message.
- Better messages for test-cloud.exe error codes.