### PR TITLE
Remove version string from showVersion output

### DIFF
--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -160,7 +160,7 @@ export class Command {
   protected showVersion(): Result.CommandResult {
     const packageJsonPath = path.join(__dirname, "../../../package.json");
     const packageJson: any = require(packageJsonPath);
-    out.text(s => s,`${scriptName} version ${packageJson.version}`);
+    out.text(s => s,`${scriptName} ${packageJson.version}`);
     return Result.success();
   }
 


### PR DESCRIPTION
Removes the `version` string from `showVersion()` output resulting in: 

```shell
$ appcenter --version
appcenter 1.0.2
```

as per jmoody's suggestion in #297 (tho still with `appcenter` ). Thoughts whether to keep as-is, remove `version`, or just print the version number?