### PR TITLE
Print version info command in help output

### DIFF
--- a/src/util/commandline/category-command.ts
+++ b/src/util/commandline/category-command.ts
@@ -26,6 +26,8 @@ export class CategoryCommand extends Command {
     out.help();
     out.help(this.categoryHelp());
     out.help();
+    out.help("For version info, use 'appcenter --version'");
+    out.help();
     const command = "<command>";
     const commandTemplate = [scriptName].concat(this.command, [command]).join(" ");
     out.help(`Usage: ${chalk.bold(commandTemplate)}`);


### PR DESCRIPTION
👋

Attempts to address #297 by printing version command similar to azure-cli:

```shell
$ node .\dist\index.js -h

Visual Studio App Center helps you build, test, distribute, and monitor mobile apps.

For version info, use 'appcenter --version'

Usage: appcenter <command>

Commands:
    analytics                      View events, audience info, sessions, and other anayltics for apps
    apps                           View and manage apps
    build                          Start builds, get their status, and download artifacts
    codepush                       View and manage CodePush deployments and releases
    crashes                        Upload symbols for better crash reports
    distribute                     Send builds to testers and manage distribution groups
    orgs                           Manage organizations
    profile                        Manage your profile
    telemetry                      Manage telemetry preferences
    test                           Start test runs and get their status
    tokens                         Manage API tokens
    help                           Get help using appcenter commands
    login                          Log in
    logout                         Log out
    setup-autocomplete             Setup tab completion for your shell
```

Thoughts? Admittedly is a bit odd to me printing before `Usage`.