### PR TITLE
Guard against non-existing profile: fix failed with exception "Cannot read property 'email' of null"

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -156,12 +156,18 @@ export abstract class RunTestsCommand extends AppCommand {
 
       let helpMessage = `Further error details: For help, please send the following information to us by going to https://mobile.azure.com/apps and starting a new conversation (using the icon in the bottom right corner of the screen)${os.EOL}
         Environment: ${os.platform()}${os.EOL}
-        User Email: ${profile.email}${os.EOL}
-        User Name: ${profile.userName}${os.EOL}
-        User Id: ${profile.userId}${os.EOL}
         App Upload Id: ${this.identifier}${os.EOL}
         Timestamp: ${Date.now()}${os.EOL}
         Operation: ${this.constructor.name}${os.EOL}`;
+
+      if (profile) {
+        helpMessage += `
+        User Email: ${profile.email}${os.EOL}
+        User Name: ${profile.userName}${os.EOL}
+        User Id: ${profile && profile.userId}${os.EOL}
+        `;
+      }
+
 
       if (err.message.indexOf("Not Found") !== -1)
       {

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -164,7 +164,7 @@ export abstract class RunTestsCommand extends AppCommand {
         helpMessage += `
         User Email: ${profile.email}${os.EOL}
         User Name: ${profile.userName}${os.EOL}
-        User Id: ${profile && profile.userId}${os.EOL}
+        User Id: ${profile.userId}${os.EOL}
         `;
       }
 


### PR DESCRIPTION
When there is not profile present and an error happens, the true error is masked by an error trying to read the user's profile. 

For example in version 1.0.2 you have
```bash
➜  ~ appcenter test run uitest --app "user/app" --devices 9c3473a9 --app-path CreditCardValidator.iOS.ipa --test-series "master" --locale "en_US" --build-dir bin/Release --uitest-tools-dir /non-existant  --token 234
Preparing tests... failed.
Error: Command 'test run uitest --app user/app --devices 9c3473a9 --app-path CreditCardValidator.iOS.ipa --test-series master --locale en_US --build-dir bin/Release --uitest-tools-dir /non-existant --token 234' failed with exception "Cannot read property 'email' of null"
```

with this change:

```bash
node dist/index.js test run uitest --app "user/app" --devices 9c3473a9 --app-path CreditCardValidator.iOS.ipa --test-series "master" --locale "en_US" --build-dir bin/Release --uitest-tools-dir /non-existant  --token 234
Preparing tests... failed.
Error: Cannot find test-cloud.exe, the path specified by "--uitest-tools-dir" was not found.
Please check that "/non-existant" is a valid directory and contains test-cloud.exe.
Minimum required version is "2.2.0".

Further error details: For help, please send the following information to us by going to https://mobile.azure.com/apps and starting a new conversation (using the icon in the bottom right corner of the screen)

        Environment: darwin

        App Upload Id: user/app

        Timestamp: 1511439664730

        Operation: RunUITestsCommand
```