### PR TITLE
[CodePush] fixed the debug function passing and private properties code

### DIFF
--- a/src/commands/codepush/lib/legacy-codepush-service-client.ts
+++ b/src/commands/codepush/lib/legacy-codepush-service-client.ts
@@ -17,35 +17,17 @@ export type Headers = { [headerName: string]: string };
 export default class LegacyCodePushServiceClient {
   private static API_VERSION: number = 2;
   
-  private _accessKey: string;
-  private _serverUrl: string;
-  private _customHeaders: Headers;
-  private _app: DefaultApp;
-  private _debug: Function;
-
-  constructor(accessKey: string, serverUrl: string, app: DefaultApp, debug: Function, customHeaders?: Headers) {
+  constructor(private accessKey: string, private serverUrl: string, private app: DefaultApp, private customHeaders?: Headers) {
     if (!accessKey) throw new Error("A token must be specified to execute server calls.");
     if (!serverUrl) throw new Error("A server url must be specified to execute server calls.");
-
-    this._accessKey = accessKey;
-    this._app = app;
-    this._debug = debug;
-    this._customHeaders = customHeaders;
-    this._serverUrl = serverUrl; 
-    this._debug(`Access token: ${accessKey}, app name ${app.appName}, server url ${serverUrl}`);
   }
 
-  private get accessKey(): string {
-    return this._accessKey;
-  }   
-
-  public release(deploymentName: string, filePath: string, updateMetadata: PackageInfo): Promise<void> {   
-    const appName = this._app.appName;
-    this._debug(`Releasing update via old service to ${this.appNameParam(appName)} app ${deploymentName} deployment`);
+  public release(deploymentName: string, filePath: string, updateMetadata: PackageInfo): Promise<void> {
+    const appName = this.app.identifier;
 
     return new Promise<void>((resolve, reject) => {
         var options = {
-          url: this._serverUrl + this.urlEncode(`/apps/${this.appNameParam(appName)}/deployments/${deploymentName}/release`),
+          url: this.serverUrl + this.urlEncode(`/apps/${this.appNameParam(appName)}/deployments/${deploymentName}/release`),
           headers: {
             "Accept": `application/vnd.code-push.v${LegacyCodePushServiceClient.API_VERSION}+json`,
             "Authorization": `Bearer ${this.accessKey}`

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -22,7 +22,7 @@ export interface ReleaseStrategy {
       isDisabled?: boolean;
       isMandatory?: boolean;
       rollout?: number;
-    }, debug: Function, token?: string, serverUrl?: string): Promise<void>
+    }, token?: string, serverUrl?: string): Promise<void>
 }
 
 export default class CodePushReleaseCommandSkeleton extends AppCommand {
@@ -112,7 +112,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
         isDisabled: this.disabled,
         isMandatory: this.mandatory,
         rollout: this.rollout
-      }, debug, token, serverUrl));
+      }, token, serverUrl));
      
       out.text(`Successfully released an update containing the "${this.updateContentsPath}" `
         + `${fs.lstatSync(this.updateContentsPath).isDirectory() ? "directory" : "file"}`

--- a/src/commands/codepush/lib/release-strategy/appcenter-release.ts
+++ b/src/commands/codepush/lib/release-strategy/appcenter-release.ts
@@ -9,7 +9,7 @@ export default class AppCenterCodePushRelease implements ReleaseStrategy {
       description?: string; 
       isDisabled?: boolean; 
       isMandatory?: boolean; 
-      rollout?: number; }, debug: Function, token?: string, serverUrl?: string): Promise<void> {
+      rollout?: number; }, token?: string, serverUrl?: string): Promise<void> {
       
       await clientRequest<models.CodePushRelease>(
         (cb) => client.codePushDeploymentReleases.create(

--- a/src/commands/codepush/lib/release-strategy/legacy-service-release.ts
+++ b/src/commands/codepush/lib/release-strategy/legacy-service-release.ts
@@ -10,7 +10,7 @@ export default class LegacyCodePushRelease implements ReleaseStrategy {
       description?: string; 
       isDisabled?: boolean; 
       isMandatory?: boolean; 
-      rollout?: number; }, debug: Function, token?: string, serverUrl?: string): Promise<void> {
+      rollout?: number; }, token?: string, serverUrl?: string): Promise<void> {
 
       var releaseData: PackageInfo = {
         description: updateMetadata.description,
@@ -20,7 +20,7 @@ export default class LegacyCodePushRelease implements ReleaseStrategy {
         appVersion: updateMetadata.appVersion
       };
 
-      await new LegacyCodePushServiceClient(token, serverUrl, app, debug, null)
+      await new LegacyCodePushServiceClient(token, serverUrl, app, null)
         .release(deploymentName, updateContentsZipPath, releaseData);   
   } 
 }


### PR DESCRIPTION
This PR fixes the issue from the previous PR #321 that @christav pointed out.

This PR fixed:

1. private constructor properties mentioned in [here](https://github.com/Microsoft/appcenter-cli/pull/321#discussion_r153288656). 
2. remove debug function to pass through [here](https://github.com/Microsoft/appcenter-cli/pull/321#discussion_r153288656).

@christav for the comment to not passing DefaultApp. Since codepush release command points to legacy one instead of the new one, this requirement makes us to think to pass the DefaultApp from higher level command to the lower level skeleton code. In other word, we do the code injection in purpose.  @max-mironov this is what I think from your written code. 
