### PR TITLE
Fix validation of `--target-binary-version`

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -129,11 +129,6 @@ export function getReactNativeProjectAppVersion(versionSearchParams: VersionSear
           // so we can safely use that and move on.
           out.text(`Using the target binary version value "${appVersion}" from "${buildGradlePath}".\n`);
           return appVersion;
-        } else if (/^\d.*/.test(appVersion)) {
-          // The versionName property isn't a valid semver string,
-          // but it starts with a number, and therefore, it can't
-          // be a valid Gradle property reference.
-          throw new Error(`The "android.defaultConfig.versionName" property in the "${buildGradlePath}" file needs to specify a valid semver string, containing both a major and minor version (e.g. 1.3.2, 1.1).`);
         }
 
         // The version property isn't a valid semver string

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -10,7 +10,7 @@ import * as chalk from "chalk";
 import { sign, zip } from "../lib/update-contents-tasks";
 import { isBinaryOrZip } from "../lib/file-utils";
 import { environments } from "../lib/environment";
-import { isValidVersion, isValidRollout, isValidDeployment } from "../lib/validation-utils";
+import { isValidRange, isValidRollout, isValidDeployment } from "../lib/validation-utils";
 import { AppCenterCodePushRelease, LegacyCodePushRelease }  from "../lib/release-strategy/index";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:release-skeleton");
@@ -132,7 +132,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       return failure(ErrorCodes.InvalidParameter, "It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
     }
 
-    if (!isValidVersion(this.targetBinaryVersion)) {
+    if (!isValidRange(this.targetBinaryVersion)) {
       return failure(ErrorCodes.InvalidParameter, "Invalid binary version(s) for a release.");
     }
 

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -4,12 +4,12 @@ import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 
 // Check if the given string is a semver-compliant version number (e.g. '1.2.3')
+// (missing minor/patch values will be added on server side to pass semver.satisfies check)
 export function isValidVersion(version: string): boolean {
-  return !!semver.valid(version);
+  return !!semver.valid(version) || /^\d+\.\d+$/.test(version) || /^\d+$/.test(version);
 }
 
 // Allow plain integer versions (as well as '1.0' values) for now, e.g. '1' is valid here and we assume that it is equal to '1.0.0'. 
-// (missing minor/patch values will be added on server side to pass semver.satisfies check)
 export function isValidRange(semverRange: string): boolean {
   return !!semver.validRange(semverRange);
 }

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -3,9 +3,15 @@ import * as semver from "semver";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 
+// Check if the given string is a semver-compliant version number (e.g. '1.2.3')
+// Ranges (e.g. '1.2.x', '>= 1.2.0' etc) are not allowed
+export function isValidVersion(version: string): boolean {
+  return !!semver.valid(version);
+}
+
 // Allow plain integer versions (as well as '1.0' values) for now, e.g. '1' is valid here and we assume that it is equal to '1.0.0'. 
 // (missing minor/patch values will be added on server side to pass semver.satisfies check)
-export function isValidVersion(semverRange: string): boolean {
+export function isValidRange(semverRange: string): boolean {
   return !!semver.validRange(semverRange) || /^\d+\.\d+$/.test(semverRange) || /^\d+$/.test(semverRange);
 }
 

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -6,7 +6,7 @@ import { DefaultApp } from "../../../util/profile";
 // Allow plain integer versions (as well as '1.0' values) for now, e.g. '1' is valid here and we assume that it is equal to '1.0.0'. 
 // (missing minor/patch values will be added on server side to pass semver.satisfies check)
 export function isValidVersion(semverRange: string): boolean {
-  return !!semver.valid(semverRange) || /^\d+\.\d+$/.test(semverRange) || /^\d+$/.test(semverRange);
+  return !!semver.validRange(semverRange) || /^\d+\.\d+$/.test(semverRange) || /^\d+$/.test(semverRange);
 }
 
 export function isValidRollout(rollout: number): boolean {

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -4,7 +4,6 @@ import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 
 // Check if the given string is a semver-compliant version number (e.g. '1.2.3')
-// Ranges (e.g. '1.2.x', '>= 1.2.0' etc) are not allowed
 export function isValidVersion(version: string): boolean {
   return !!semver.valid(version);
 }
@@ -12,7 +11,7 @@ export function isValidVersion(version: string): boolean {
 // Allow plain integer versions (as well as '1.0' values) for now, e.g. '1' is valid here and we assume that it is equal to '1.0.0'. 
 // (missing minor/patch values will be added on server side to pass semver.satisfies check)
 export function isValidRange(semverRange: string): boolean {
-  return !!semver.validRange(semverRange) || /^\d+\.\d+$/.test(semverRange) || /^\d+$/.test(semverRange);
+  return !!semver.validRange(semverRange);
 }
 
 export function isValidRollout(rollout: number): boolean {

--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -3,7 +3,7 @@ import { out } from "../../util/interaction";
 import { inspect } from "util";
 import { AppCenterClient, models, clientRequest } from "../../util/apis";
 import * as chalk from "chalk";
-import { isValidRollout, isValidVersion } from "./lib/validation-utils";
+import { isValidRollout, isValidRange } from "./lib/validation-utils";
 import { DefaultApp } from "../../util/profile";
 import { scriptName } from "../../util/misc";
 
@@ -68,7 +68,7 @@ export default class PatchCommand extends AppCommand {
         return failure(ErrorCodes.Exception, `Rollout value should be integer value between ${chalk.bold('0')} or ${chalk.bold('100')}.`);
     }
 
-    if (this.targetBinaryRange != null && !isValidVersion(this.targetBinaryRange)) {
+    if (this.targetBinaryRange != null && !isValidRange(this.targetBinaryRange)) {
       return failure(ErrorCodes.Exception, "Invalid binary version(s) for a release.");
     }
 

--- a/src/commands/codepush/promote.ts
+++ b/src/commands/codepush/promote.ts
@@ -3,7 +3,7 @@ import { AppCenterClient, models, clientRequest } from "../../util/apis";
 import { out } from "../../util/interaction";
 import { inspect } from "util";
 import * as chalk from "chalk";
-import { isValidRollout, isValidVersion } from "./lib/validation-utils";
+import { isValidRollout, isValidRange } from "./lib/validation-utils";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:promote");
 
@@ -72,7 +72,7 @@ export default class CodePushPromoteCommand extends AppCommand {
       return failure(ErrorCodes.Exception, `Rollout value should be integer value between ${chalk.bold('0')} or ${chalk.bold('100')}.`);
     }
 
-    if (this.targetBinaryRange != null && !isValidVersion(this.targetBinaryRange)) {
+    if (this.targetBinaryRange != null && !isValidRange(this.targetBinaryRange)) {
       return failure(ErrorCodes.Exception, "Invalid binary version(s) for a release.");
     }
 

--- a/src/commands/codepush/release-cordova.ts
+++ b/src/commands/codepush/release-cordova.ts
@@ -5,7 +5,7 @@ import { out } from "../../util/interaction";
 import { inspect } from "util";
 import * as chalk from "chalk";
 import * as path from "path";
-import { isValidVersion, isValidDeployment } from "./lib/validation-utils";
+import { isValidRange, isValidDeployment } from "./lib/validation-utils";
 import { isValidOS, isValidPlatform, getCordovaOrPhonegapCLI, getCordovaProjectAppVersion } from "./lib/cordova-utils";
 
 var childProcess = require("child_process");
@@ -60,7 +60,7 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
       this.targetBinaryVersion = await getCordovaProjectAppVersion();
     }
 
-    if (!isValidVersion(this.targetBinaryVersion)) {
+    if (!isValidRange(this.targetBinaryVersion)) {
       return failure(ErrorCodes.InvalidParameter, "Invalid binary version(s) for a release.");
     }
 

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -8,7 +8,7 @@ import * as pfs from "../../util/misc/promisfied-fs";
 import * as chalk from "chalk";
 import * as path from "path";
 import { fileDoesNotExistOrIsDirectory, createEmptyTmpReleaseFolder, removeReactTmpDir } from "./lib/file-utils";
-import { isValidVersion, isValidDeployment } from "./lib/validation-utils";
+import { isValidRange, isValidDeployment } from "./lib/validation-utils";
 import { VersionSearchParams, getReactNativeProjectAppVersion, runReactNativeBundleCommand, isValidOS, isValidPlatform, isReactNativeProject } from "./lib/react-native-utils";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:release-react");
@@ -126,7 +126,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
 
     this.targetBinaryVersion = this.specifiedTargetBinaryVersion;
 
-    if (this.targetBinaryVersion && !isValidVersion(this.targetBinaryVersion)) {
+    if (this.targetBinaryVersion && !isValidRange(this.targetBinaryVersion)) {
       return failure(ErrorCodes.InvalidParameter, "Invalid binary version(s) for a release.");
     } else if (!this.targetBinaryVersion) {
       const versionSearchParams: VersionSearchParams = {

--- a/test/commands/codepush/lib/validation-utils-test.ts
+++ b/test/commands/codepush/lib/validation-utils-test.ts
@@ -1,0 +1,96 @@
+import { isValidVersion, isValidRange } from "../../../../src/commands/codepush/lib/validation-utils";
+import { expect } from "chai";
+
+describe('isValidVersion', function() {
+  context('when a given version is semver-compliant', function() {
+    const semverCompliantVersions = [
+      '1.2.0',
+      '1.2.3',
+      '1.2.10',
+    ];
+
+    it('returns true', function() {
+      for (const version of semverCompliantVersions) {
+        expect(isValidVersion(version)).to.be.true;
+      }
+    });
+  });
+
+  context('when a given version lacks the patch version', function() {
+    const majorAndMinorVersions = [
+      '1.2',
+      '1.10',
+    ];
+
+    it('returns true', function() {
+      for (const version of majorAndMinorVersions) {
+        expect(isValidVersion(version)).to.be.true;
+      }
+    });
+  });
+
+  context('when a given version lacks the minor/patch versions', function() {
+    const majorVersions = [
+      '1',
+      '10'
+    ];
+
+    it('returns true', function() {
+      for (const version of majorVersions) {
+        expect(isValidVersion(version)).to.be.true;
+      }
+    });
+  });
+
+  context('when a given version is invalid', function() {
+    const invalidVersions = [
+      '1.',
+      '1.2.',
+      '1.2.3.',
+      '1.invalid',
+    ];
+
+    it('returns false', function() {
+      for (const version of invalidVersions) {
+        expect(isValidVersion(version)).to.be.false;
+      }
+    });
+  });
+});
+
+describe('isValidRange', function() {  
+  context('when a given version range is semver-compliant', function() {
+    const semverCompliantRanges = [
+      '1.2.3',
+      '*',
+      '1.2.x',
+      '1.2.3 - 1.2.7',
+      '>=1.2.3 <1.2.7',
+      '~1.2.3',
+      '^1.2.3',
+      '1.2',
+      '1',
+    ];
+
+    it('returns true', function() {
+      for (const range of semverCompliantRanges) {
+        expect(isValidRange(range)).to.be.true;
+      }
+    });
+  });
+
+  context('when a given version range is not semver-compliant', function() {
+    const invalidRanges = [
+      '1.',
+      '1.2.',
+      '1.2.3.',
+      '1.invalid',
+    ];
+
+    it('returns false', function() {
+      for (const range of invalidRanges) {
+        expect(isValidRange(range)).to.be.false;
+      }
+    })
+  });
+});


### PR DESCRIPTION
Currently, I can't specify `--target-binary-version` using semver range.

```
$ appcenter codepush release-react -a MyOrg/MyApp --deployment-name Staging --target-binary-version '1.2.x'
Error: Invalid binary version(s) for a release.
```

The document says strings `1.2.x` should be allowed.
https://docs.microsoft.com/en-us/appcenter/distribution/codepush/cli#target-binary-version-parameter

If the version is like `1.2.0`, it runs successfully.

I figured out the cause of the error and fixed it.
It's because of the usage of `semver` npm package.

```js
var semver = require('semver');

console.dir(semver.valid('1.2.0'));
// => '1.2.0

console.dir(semver.valid('1.2.x'));
// => null

console.dir(semver.validRange('1.2.0'));
// => '1.2.0

console.dir(semver.validRange('1.2.x'));
// => '>=1.2.0 <1.3.0'

console.dir(semver.validRange('1.2.invalid'));
// => null
```