### PR TITLE
Provide portal endpoint for testCloudLocalDev env config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4550,11 +4550,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4564,6 +4559,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/src/util/profile/environments.ts
+++ b/src/util/profile/environments.ts
@@ -46,7 +46,7 @@ const environmentsData: EnvironmentsFile = {
     testCloudLocalDev: {
       endpoint: "http://localhost:1700",
       loginEndpoint: null,
-      portalEndpoint: null,
+      portalEndpoint: "http://localhost:8080",
       description: "Test Cloud local dev box development"
     }
   }


### PR DESCRIPTION
### Motivation

Upon attempting to submit an upload to a local instance of Asgard/Bifrost/XTC, I discovered that we get a fatal error that `portalBaseUrl` is `nil`.  Investigation and experimentation led me to realize that this `portalEndpoint` value needs to be set in order for login to succeed locally.

I left `loginEndpoint` as `null` because it appears that, when specified, `appcenter-cli` requires interactive login which is not an ideal workflow for our dev environment. 