### PR TITLE
Feature/validate token on create client

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -89,7 +89,7 @@ export default class LoginCommand extends Command {
     }
 
     const endpoint = environments(this.environmentName).endpoint;
-    const client = this.clientFactory.fromUserNameAndPassword(this.userName, this.password, endpoint);
+    const client = await this.clientFactory.fromUserNameAndPassword(this.userName, this.password, endpoint);
 
     let createTokenResponse = await out.progress("Logging in...",
       clientRequest<models.ApiTokensCreateResponse>(cb => client.apiTokens.newMethod({ description: "AppCenter CLI"}, cb)));
@@ -134,9 +134,9 @@ export default class LoginCommand extends Command {
     return [];
   }
 
-  private getUserInfo(token: string): Promise<ClientResponse<models.UserProfileResponse>> {
+  private async getUserInfo(token: string): Promise<ClientResponse<models.UserProfileResponse>> {
     const endpoint = environments(this.environmentName).endpoint;
-    const client = this.clientFactory.fromToken(token, endpoint);
+    const client = await this.clientFactory.fromToken(token, endpoint);
     return clientRequest<models.UserProfileResponse>(cb => client.users.get(cb));
   }
 
@@ -146,7 +146,7 @@ export default class LoginCommand extends Command {
       debug(`Currently logged in as ${currentUser.userName}, removing token`);
 
       debug(`Creating client factory`);
-      const client = this.clientFactory.fromProfile(currentUser);
+      const client = await this.clientFactory.fromProfile(currentUser);
       debug(`Removing existing token`);
       await logout(client, currentUser);
     }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -169,7 +169,7 @@ export abstract class RunTestsCommand extends AppCommand {
       }
 
 
-      if (err.message.indexOf("Not Found") !== -1)
+      if (err.message && err.message.indexOf("Not Found") !== -1)
       {
         message = `Requested resource not found - please check --app: ${this.identifier}${os.EOL}${os.EOL}${helpMessage}`;
       }

--- a/src/commands/tokens/lib/token-helper.ts
+++ b/src/commands/tokens/lib/token-helper.ts
@@ -1,0 +1,25 @@
+import { AppCenterClient, models, clientRequest, ClientResponse } from "../../../util/apis";
+import { failure, ErrorCodes } from "../../../util/commandline";
+import { inspect } from "util";
+
+const debug = require("debug")("appcenter-cli:commands:tokens:lib:token-helper");
+
+export async function checkToken(client: AppCenterClient): Promise<boolean> {
+  try {
+    //TODO: Change this to call a purpose built api endpoint for this purpose:
+    const httpResponse = await clientRequest<models.ApiTokensGetResponse[]>((cb) => client.apiTokens.list(cb));
+    if (httpResponse.response.statusCode < 400) {
+      return true;
+    } else {
+      throw httpResponse.response;
+    }
+  } catch (error) {
+    if (error.statusCode === 401) {
+      debug(`Invalid token tokens- ${inspect(error)}`);
+      false;
+    } else {
+      debug(`Failed to load list of tokens- ${inspect(error)}`);
+      throw failure(ErrorCodes.Exception, "failed to load list of tokens");
+    }
+  }
+}

--- a/src/commands/tokens/lib/token-helper.ts
+++ b/src/commands/tokens/lib/token-helper.ts
@@ -4,7 +4,17 @@ import { inspect } from "util";
 
 const debug = require("debug")("appcenter-cli:commands:tokens:lib:token-helper");
 
-export async function checkToken(client: AppCenterClient): Promise<boolean> {
+export interface TokenValidator {
+  tokenIsValid(client: AppCenterClient) : Promise<boolean>
+}
+
+export class tokenValidator implements TokenValidator {
+  async tokenIsValid(client: AppCenterClient) : Promise<boolean> {
+    return await checkToken(client);
+  }
+}
+
+async function checkToken(client: AppCenterClient): Promise<boolean> {
   try {
     //TODO: Change this to call a purpose built api endpoint for this purpose:
     const httpResponse = await clientRequest<models.ApiTokensGetResponse[]>((cb) => client.apiTokens.list(cb));

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -7,7 +7,7 @@ import AppCenterClient = require("./generated/appCenterClient");
 import { AppCenterClientCredentials } from "./appcenter-client-credentials";
 import { userAgentFilter } from "./user-agent-filter";
 import { telemetryFilter } from "./telemetry-filter";
-import { checkToken } from "../../commands/tokens/lib/token-helper";
+import { TokenValidator } from "../../commands/tokens/lib/token-helper";
 
 const BasicAuthenticationCredentials = require("ms-rest").BasicAuthenticationCredentials;
 import { ServiceCallback, ServiceError, WebResource } from "ms-rest";
@@ -23,7 +23,7 @@ export interface AppCenterClientFactory {
   fromProfile(user: Profile): Promise<AppCenterClient>;
 }
 
-export function createAppCenterClient(command: string[], telemetryEnabled: boolean): AppCenterClientFactory {
+export function createAppCenterClient(command: string[], telemetryEnabled: boolean, tokenValidator: TokenValidator): AppCenterClientFactory {
   function createClientOptions(): any {
     debug(`Creating client options, isDebug = ${isDebug()}`);
     const filters = [userAgentFilter, telemetryFilter(command.join(" "), telemetryEnabled)];
@@ -54,7 +54,7 @@ export function createAppCenterClient(command: string[], telemetryEnabled: boole
       }
       debug(`Passing token ${tokenFunc} of type ${typeof tokenFunc}`);
       let client = new AppCenterClient(new AppCenterClientCredentials(tokenFunc), endpoint, createClientOptions());
-      let validToken = await checkToken(client);
+      let validToken = true; //await tokenValidator.tokenIsValid(client);
 
       if (validToken)
       {

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -16,7 +16,6 @@ const createLogger = require('ms-rest').LogFilter.create;
 
 import { isDebug } from "../interaction";
 import { Profile } from "../profile";
-import { valid } from "semver";
 
 export interface AppCenterClientFactory {
   fromUserNameAndPassword(userName: string, password: string, endpoint: string): Promise<AppCenterClient>;

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -54,7 +54,7 @@ export function createAppCenterClient(command: string[], telemetryEnabled: boole
       }
       debug(`Passing token ${tokenFunc} of type ${typeof tokenFunc}`);
       let client = new AppCenterClient(new AppCenterClientCredentials(tokenFunc), endpoint, createClientOptions());
-      let validToken = true; //await tokenValidator.tokenIsValid(client);
+      let validToken = await tokenValidator.tokenIsValid(client);
 
       if (validToken)
       {

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -7,6 +7,7 @@ import AppCenterClient = require("./generated/appCenterClient");
 import { AppCenterClientCredentials } from "./appcenter-client-credentials";
 import { userAgentFilter } from "./user-agent-filter";
 import { telemetryFilter } from "./telemetry-filter";
+import { checkToken } from "../../commands/tokens/lib/token-helper";
 
 const BasicAuthenticationCredentials = require("ms-rest").BasicAuthenticationCredentials;
 import { ServiceCallback, ServiceError, WebResource } from "ms-rest";
@@ -15,11 +16,12 @@ const createLogger = require('ms-rest').LogFilter.create;
 
 import { isDebug } from "../interaction";
 import { Profile } from "../profile";
+import { valid } from "semver";
 
 export interface AppCenterClientFactory {
-  fromUserNameAndPassword(userName: string, password: string, endpoint: string): AppCenterClient;
-  fromToken(token: string | Promise<string> | {(): Promise<string>}, endpoint: string): AppCenterClient;
-  fromProfile(user: Profile): AppCenterClient;
+  fromUserNameAndPassword(userName: string, password: string, endpoint: string): Promise<AppCenterClient>;
+  fromToken(token: string | Promise<string> | {(): Promise<string>}, endpoint: string): Promise<AppCenterClient>;
+  fromProfile(user: Profile): Promise<AppCenterClient>;
 }
 
 export function createAppCenterClient(command: string[], telemetryEnabled: boolean): AppCenterClientFactory {
@@ -32,12 +34,12 @@ export function createAppCenterClient(command: string[], telemetryEnabled: boole
   }
 
   return {
-    fromUserNameAndPassword(userName: string, password: string, endpoint: string): AppCenterClient {
+    async fromUserNameAndPassword(userName: string, password: string, endpoint: string): Promise<AppCenterClient> {
       debug(`Creating client from user name and password for endpoint ${endpoint}`);
       return new AppCenterClient(new BasicAuthenticationCredentials(userName, password), endpoint, createClientOptions());
     },
 
-    fromToken(token: string | Promise<string> | {(): Promise<string>}, endpoint: string): AppCenterClient {
+    async fromToken(token: string | Promise<string> | {(): Promise<string>}, endpoint: string): Promise<AppCenterClient> {
       debug(`Creating client from token for endpoint ${endpoint}`);
       let tokenFunc: {(): Promise<string>};
 
@@ -52,10 +54,18 @@ export function createAppCenterClient(command: string[], telemetryEnabled: boole
         tokenFunc = token;
       }
       debug(`Passing token ${tokenFunc} of type ${typeof tokenFunc}`);
-      return new AppCenterClient(new AppCenterClientCredentials(tokenFunc), endpoint, createClientOptions());
+      let client = new AppCenterClient(new AppCenterClientCredentials(tokenFunc), endpoint, createClientOptions());
+      let validToken = await checkToken(client);
+
+      if (validToken)
+      {
+        return client;
+      }
+
+      return null;
     },
 
-    fromProfile(user: Profile): AppCenterClient {
+    async fromProfile(user: Profile): Promise<AppCenterClient> {
       if (!user) {
         debug(`No current user, not creating client`);
         return null;
@@ -84,7 +94,7 @@ export interface ClientResponse<T> {
   response: IncomingMessage;
 }
 
-// Helper function to wrap client calls into pormises and returning both HTTP response and parsed result
+// Helper function to wrap client calls into promises and returning both HTTP response and parsed result
 export function clientRequest<T>(action: {(cb: ServiceCallback<any>): void}): Promise<ClientResponse<T>> {
   return new Promise<ClientResponse<T>>((resolve, reject) => {
     action((err: Error | ServiceError, result: T, request: WebResource, response: IncomingMessage) => {

--- a/src/util/commandline/command-result.ts
+++ b/src/util/commandline/command-result.ts
@@ -95,6 +95,11 @@ export function notLoggedIn(command: string): CommandResult {
     `Command '${command}' requires a logged in user. Use the '${scriptName} login' command to log in.`);
 }
 
+export function incorrectToken(command: string): CommandResult {
+  return failure(ErrorCodes.NotLoggedIn,
+    `Command '${command}' requires a valid token. Please check the --token and regenerate if it's correct and you still see this message.`);
+}
+
 export function exception(command: string, ex: Error): CommandResult {
   return {
     succeeded: false,

--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -7,6 +7,7 @@ import { runHelp } from "./help";
 import { scriptName } from "../misc";
 import { getUser, environments, telemetryIsEnabled, getPortalUrlForEndpoint, getEnvFromEnvironmentVar, getTokenFromEnvironmentVar, appCenterAccessTokenEnvVar } from "../profile";
 import { AppCenterClient, createAppCenterClient, AppCenterClientFactory } from "../apis";
+import { tokenValidator } from "../../commands/tokens/lib/token-helper";
 import * as path from "path";
 import * as PortalHelper from "../portal/portal-helper";
 
@@ -84,7 +85,7 @@ export class Command {
   public disableTelemetry: boolean;
 
   // Entry point for runner. DO NOT override in command definition!
-  async execute(): Promise<Result.CommandResult> {
+  async execute(validator : tokenValidator = new tokenValidator()): Promise<Result.CommandResult> {
     debug(`Initial execution of command`);
     if (this.help) {
       debug(`help switch detected, displaying help for command`);
@@ -112,7 +113,7 @@ export class Command {
         return Promise.resolve(Result.failure(Result.ErrorCodes.InvalidParameter, `Unknown output format ${this.format}`));
       }
     }
-    this.clientFactory = createAppCenterClient(this.command, await telemetryIsEnabled(this.disableTelemetry));
+    this.clientFactory = createAppCenterClient(this.command, await telemetryIsEnabled(this.disableTelemetry), validator);
     return this.runNoClient();
   }
 

--- a/test/commands/crashes/upload-symbols/upload-symbols-test.ts
+++ b/test/commands/crashes/upload-symbols/upload-symbols-test.ts
@@ -3,6 +3,7 @@ import { expect, use } from "chai";
 import * as Fs from "fs";
 import * as Pfs from "../../../../src/util/misc/promisfied-fs";
 import { IncomingMessage } from "http";
+import { TokenValidator, tokenValidator } from "../../../../src/commands/tokens/lib/token-helper";
 import * as _ from "lodash";
 import * as Nock from "nock";
 import * as Path from "path";
@@ -226,7 +227,10 @@ describe("upload-symbols command", () => {
 
   async function executeUploadCommand(args: string[]): Promise<CommandResult> {
     let uploadSymbolsCommand = new UploadSymbolsCommand(getCommandArgs(args));
-    return await uploadSymbolsCommand.execute();
+    let validator = new tokenValidator;
+    let stub = Sinon.stub(validator, "tokenIsValid").returns(Promise.resolve(true));
+    let output = await uploadSymbolsCommand.execute(validator);
+    return output;
   }
 
   function testCommandSuccess(result: CommandResult, executionScope: Nock.Scope, abortScope: Nock.Scope) {

--- a/test/commands/distribute/groups/download/download-test.ts
+++ b/test/commands/distribute/groups/download/download-test.ts
@@ -4,9 +4,11 @@ import * as Nock from "nock";
 import * as Path from "path";
 import * as Temp from "temp";
 import * as _ from "lodash";
+import * as Sinon from "sinon";
 
 import DownloadBinaryFromDistributionGroupCommand from "../../../../../src/commands/distribute/groups/download";
 import { CommandArgs, CommandResult } from "../../../../../src/util/commandline";
+import { TokenValidator, tokenValidator } from "../../../../../src/commands/tokens/lib/token-helper";
 
 Temp.track();
 
@@ -25,6 +27,7 @@ describe("distribute groups download command", () => {
   const releaseFileContent2 = "Hello again!";
 
   let tmpFolderPath: string;
+  let validator: TokenValidator;
 
   before(() => {
     Nock.disableNetConnect();
@@ -32,6 +35,9 @@ describe("distribute groups download command", () => {
 
   beforeEach(() => {
     tmpFolderPath = Temp.mkdirSync("groupsDownloadTest");
+
+    validator = new tokenValidator();
+    let stub = Sinon.stub(validator, "tokenIsValid").returns(Promise.resolve(true));
   });
 
   it("gets the latest release when no release is specified", async () => {
@@ -43,7 +49,7 @@ describe("distribute groups download command", () => {
     // Act 
     const command = new DownloadBinaryFromDistributionGroupCommand(
       getCommandArgs(["-g", fakeDistributionGroupName, "-f", Path.basename(releaseFilePath), "-d", Path.dirname(releaseFilePath)]));
-    const result = await command.execute();
+    const result = await command.execute(validator);
 
     // Assert
     testCommandSuccess(result, executionScope, skippedScope);
@@ -60,7 +66,7 @@ describe("distribute groups download command", () => {
     // Act 
     const command = new DownloadBinaryFromDistributionGroupCommand(
       getCommandArgs(["-g", fakeDistributionGroupName, "-f", Path.basename(releaseFilePath), "-d", Path.dirname(releaseFilePath), "-i", fakeReleaseId]));
-    const result = await command.execute();
+    const result = await command.execute(validator);
 
     // Assert
     testCommandSuccess(result, executionScope, skippedScope);


### PR DESCRIPTION
### Motivation
Currently if the wrong --token is sent - the system doesn't flag this up until the first API call. This PR is to check an API call sooner and return a helpful error message.

### Disclaimer
I'm relatively new to TypeScript - please let me know if I've done anything incorrect here. I've had to:
1. Convert a load of stuff to async so we can access the API.
2. Introduce some constructor injection to pass through a stubbed `tokenValidator` so tests still pass.

I'm creating this PR early for discussion so please let me know if anything needs to change for acceptance.