### PR TITLE
Fix/bad error on 401

### DIFF
--- a/src/commands/orgs/lib/org-users-helper.ts
+++ b/src/commands/orgs/lib/org-users-helper.ts
@@ -15,6 +15,9 @@ export async function getOrgUsers(client: AppCenterClient, organization: string,
   } catch (error) {
     if (error.statusCode === 404) {
       throw failure(ErrorCodes.InvalidParameter, `organization ${organization} doesn't exist`);
+    }
+    if (error.statusCode === 401) {
+      throw failure(ErrorCodes.NotLoggedIn, `Failed to load list of organization users - unauthorized error`);
     } else {
       debug(`Failed to load list of organization users - ${inspect(error)}`);
       throw failure(ErrorCodes.Exception, "failed to load list of organization users");
@@ -35,8 +38,12 @@ export async function getOrgsNamesList(client: AppCenterClient): Promise<IEntity
       throw httpResponse.response;
     }
   } catch (error) {
-    debug(`Failed to load list of organization for current user - ${inspect(error)}`);
-    throw failure(ErrorCodes.Exception, "failed to load list of organization for the user");
+    if (error.statusCode === 401) {
+      throw failure(ErrorCodes.NotLoggedIn, `Failed to load list of organization users - unauthorized error`);
+    } else {
+      debug(`Failed to load list of organization for current user - ${inspect(error)}`);
+      throw failure(ErrorCodes.Exception, "failed to load list of organization for the user");
+    }
   }
 }
 

--- a/src/commands/orgs/lib/org-users-helper.ts
+++ b/src/commands/orgs/lib/org-users-helper.ts
@@ -1,6 +1,7 @@
 import { AppCenterClient, models, clientRequest, ClientResponse } from "../../../util/apis";
 import { failure, ErrorCodes } from "../../../util/commandline";
 import { inspect } from "util";
+import { handleHttpError } from "../../../util/apis/create-client";
 
 const debug = require("debug")("appcenter-cli:commands:orgs:lib:org-users-helper");
 
@@ -13,15 +14,8 @@ export async function getOrgUsers(client: AppCenterClient, organization: string,
       throw httpResponse.response;
     }
   } catch (error) {
-    if (error.statusCode === 404) {
-      throw failure(ErrorCodes.InvalidParameter, `organization ${organization} doesn't exist`);
-    }
-    if (error.statusCode === 401) {
-      throw failure(ErrorCodes.NotLoggedIn, `Failed to load list of organization users - unauthorized error`);
-    } else {
-      debug(`Failed to load list of organization users - ${inspect(error)}`);
-      throw failure(ErrorCodes.Exception, "failed to load list of organization users");
-    }
+    await handleHttpError(error, true, "failed to load list of organization users",
+    `organization ${organization} doesn't exist`);
   }
 }
 
@@ -38,12 +32,7 @@ export async function getOrgsNamesList(client: AppCenterClient): Promise<IEntity
       throw httpResponse.response;
     }
   } catch (error) {
-    if (error.statusCode === 401) {
-      throw failure(ErrorCodes.NotLoggedIn, `Failed to load list of organization users - unauthorized error`);
-    } else {
-      debug(`Failed to load list of organization for current user - ${inspect(error)}`);
-      throw failure(ErrorCodes.Exception, "failed to load list of organization for the user");
-    }
+    await handleHttpError(error, false, "failed to load list of organization users");
   }
 }
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -169,7 +169,7 @@ export abstract class RunTestsCommand extends AppCommand {
       }
 
 
-      if (err.message.indexOf("Not Found") !== -1)
+      if (err.message && err.message.indexOf("Not Found") !== -1)
       {
         message = `Requested resource not found - please check --app: ${this.identifier}${os.EOL}${os.EOL}${helpMessage}`;
       }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -150,28 +150,36 @@ export abstract class RunTestsCommand extends AppCommand {
       }
     }
     catch (err) {
-      let exitCode = err.exitCode || ErrorCodes.Exception;
+      let exitCode = err.exitCode || err.errorCode || ErrorCodes.Exception;
       let message : string = null;
       let profile = getUser();
 
       let helpMessage = `Further error details: For help, please send both the reported error above and the following environment information to us by going to https://appcenter.ms/apps and starting a new conversation (using the icon in the bottom right corner of the screen)${os.EOL}
-        Environment: ${os.platform()}${os.EOL}
-        App Upload Id: ${this.identifier}${os.EOL}
-        Timestamp: ${Date.now()}${os.EOL}
-        Operation: ${this.constructor.name}${os.EOL}`;
+        Environment: ${os.platform()}
+        App Upload Id: ${this.identifier}
+        Timestamp: ${Date.now()}
+        Operation: ${this.constructor.name}
+        Exit Code: ${exitCode}`;
 
       if (profile) {
         helpMessage += `
-        User Email: ${profile.email}${os.EOL}
-        User Name: ${profile.userName}${os.EOL}
-        User Id: ${profile.userId}${os.EOL}
+        User Email: ${profile.email}
+        User Name: ${profile.userName}
+        User Id: ${profile.userId}
         `;
       }
-
 
       if (err.message && err.message.indexOf("Not Found") !== -1)
       {
         message = `Requested resource not found - please check --app: ${this.identifier}${os.EOL}${os.EOL}${helpMessage}`;
+      }
+      if (err.errorCode === 5)
+      {
+        message = `Unauthorized error - please check --token or log in to the appcenter CLI.${os.EOL}${os.EOL}${helpMessage}`;
+      }
+      else if (err.errorMessage)
+      {
+        message = `${err.errorMessage}${os.EOL}${os.EOL}${helpMessage}`;
       }
       else
       {

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -16,6 +16,7 @@ const createLogger = require('ms-rest').LogFilter.create;
 import { isDebug } from "../interaction";
 import { Profile } from "../profile";
 import { Exception } from "./generated/models/index";
+import { failure, success, ErrorCodes } from "../../util/commandline/command-result";
 
 export interface AppCenterClientFactory {
   fromUserNameAndPassword(userName: string, password: string, endpoint: string): AppCenterClient;
@@ -83,6 +84,22 @@ export function clientCall<T>(action: {(cb: ServiceCallback<any>): void}): Promi
 export interface ClientResponse<T> {
   result: T;
   response: IncomingMessage;
+}
+
+export async function handleHttpError(error: any, check404: boolean, 
+    messageDefault: string, message404: string = `404 Error received from api`, message401: string = `401 Error received from api`): Promise<void> {
+  if (check404 && error.statusCode === 404) {
+    throw failure(ErrorCodes.InvalidParameter, message404);
+  }
+  
+  if (error.statusCode === 401) {
+    throw failure(ErrorCodes.NotLoggedIn, message401);
+  }
+  
+  else {
+    debug(`${messageDefault}- ${inspect(error)}`);
+    throw failure(ErrorCodes.Exception, messageDefault);
+  }
 }
 
 // Helper function to wrap client calls into pormises and returning both HTTP response and parsed result

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -15,6 +15,7 @@ const createLogger = require('ms-rest').LogFilter.create;
 
 import { isDebug } from "../interaction";
 import { Profile } from "../profile";
+import { Exception } from "./generated/models/index";
 
 export interface AppCenterClientFactory {
   fromUserNameAndPassword(userName: string, password: string, endpoint: string): AppCenterClient;

--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -15,7 +15,6 @@ const createLogger = require('ms-rest').LogFilter.create;
 
 import { isDebug } from "../interaction";
 import { Profile } from "../profile";
-import { Exception } from "./generated/models/index";
 import { failure, success, ErrorCodes } from "../../util/commandline/command-result";
 
 export interface AppCenterClientFactory {


### PR DESCRIPTION
### Motivation
Currently 401 errors are badly reported by the system.

### Solution
This PoC throws a better error when the first operation on the run test process fails and then reports that error to the user.

If we decide to go with this method - we need to:
1. Refactor the error catching code used whenever the API service is called (so that a consistent approach to 401s can be applied.
2. Update all areas of code where the API service call is used to use this new function.