### PR TITLE
adding `common` property decorator to switch options and use it to disable better example and options

### DIFF
--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -1,6 +1,6 @@
 // Base class for all command handlers
 import * as Result from "./command-result";
-import { shortName, longName, help, hasArg, getOptionsDescription, getPositionalOptionsDescription } from "./option-decorators";
+import { shortName, longName, help, hasArg, getOptionsDescription, getPositionalOptionsDescription, common } from "./option-decorators";
 import { OptionsDescription, PositionalOptionsDescription, parseOptions } from "./option-parser";
 import { setDebug, isDebug, setQuiet, OutputFormatSupport, setFormatJson, out } from "../interaction";
 import { runHelp } from "./help";
@@ -47,40 +47,48 @@ export class Command {
 
   @longName("debug")
   @help("Display extra output for debugging")
+  @common
   public debug: boolean;
 
   @longName("output")
   @hasArg
   @help("Output format: json")
+  @common
   public format: string;
 
   @longName("token")
   @hasArg
   @help("API token")
+  @common
   public token: string;
 
   @longName("env")
   @hasArg
   @help("Environment when using API token")
+  @common
   public environmentName: string;
 
   @shortName("h")
   @longName("help")
   @help("Display help for current command")
+  @common
   public help: boolean;
 
   @longName("quiet")
   @help("Auto-confirm any prompts without waiting for input")
+  @common
   public quiet: boolean;
 
   @shortName("v")
   @longName("version")
   @help(`Display ${scriptName} version`)
+  @common
   public version: boolean;
 
 
   @longName("disable-telemetry")
   @help("Disable telemetry for this command")
+  @common
   public disableTelemetry: boolean;
 
   // Entry point for runner. DO NOT override in command definition!

--- a/src/util/commandline/help.ts
+++ b/src/util/commandline/help.ts
@@ -29,6 +29,7 @@ export function runHelp(commandPrototype: any, commandObj: any): void {
   const commandExample: string = getCommandExample(commandPrototype, commandObj);
   const commandHelp: string = getCommandHelp(commandObj);
   const optionsHelpTable: any = getOptionsHelpTable(commandPrototype);
+  const commonSwitchOptionsHelpTable: any = getCommonSwitchOptionsHelpTable(commandPrototype);
 
   out.help();
   out.help(commandHelp);
@@ -39,6 +40,12 @@ export function runHelp(commandPrototype: any, commandObj: any): void {
     out.help();
     out.help("Options:");
     out.help(optionsHelpTable.toString());
+  }
+
+  if (commonSwitchOptionsHelpTable.length > 0) {
+    out.help();
+    out.help("Common Options (works on all commands):");
+    out.help(commonSwitchOptionsHelpTable.toString());
   }
 }
 
@@ -69,9 +76,17 @@ function toSwitchOptionHelp(option: OptionDescription): SwitchOptionHelp {
 
 function getOptionsHelpTable(commandPrototype: any): any {
   const nonCommonSwitchOpts = getSwitchOptionsHelp(commandPrototype, false);
-  const commonSwitchOpts = getSwitchOptionsHelp(commandPrototype, true);
   const posOpts = getPositionalOptionsHelp(commandPrototype);
-  const opts = styleOptsTable(nonCommonSwitchOpts.concat(posOpts).concat(commonSwitchOpts));
+  return getStyledOptionsHelpTable(nonCommonSwitchOpts.concat(posOpts));
+}
+
+function getCommonSwitchOptionsHelpTable(commandPrototype: any): any {
+  const commonSwitchOpts = getSwitchOptionsHelp(commandPrototype, true);
+  return getStyledOptionsHelpTable(commonSwitchOpts);
+}
+
+function getStyledOptionsHelpTable(options: string[][]): any {
+  const opts = styleOptsTable(options);
 
   // Calculate max length of the strings from the first column (switches/positional parameters) - it will be a width for the first column;
   const firstColumnWidth = opts.reduce((contenderMaxWidth, optRow) => Math.max(optRow[0].length, contenderMaxWidth), 0);

--- a/src/util/commandline/option-decorators.ts
+++ b/src/util/commandline/option-decorators.ts
@@ -130,6 +130,7 @@ export const shortName = makeStringDecorator("shortName");
 export const longName = makeStringDecorator("longName");
 
 export const hasArg = makeBoolDecorator("hasArg");
+export const common = makeBoolDecorator('common');
 
 function makePositionalDecorator<T>(descriptionFieldName: string): PropertyDecoratorBuilder<T> {
   return function positionalDecoratorBuilder(value: T): PropertyDecorator {

--- a/src/util/commandline/option-parser.ts
+++ b/src/util/commandline/option-parser.ts
@@ -12,6 +12,7 @@ export interface OptionDescription {
   defaultValue?: string; // Default value for this option if it's not present
   hasArg?: boolean;      // Does this option take an argument?
   helpText?: string;     // Help text for this parameter
+  common?: boolean;      // Is this option an common option?
 }
 
 export interface OptionsDescription {

--- a/test/util/commandline/option-decorators-test.ts
+++ b/test/util/commandline/option-decorators-test.ts
@@ -3,7 +3,8 @@ import { expect } from "chai";
 import { OptionsDescription, OptionDescription, PositionalOptionsDescription, PositionalOptionDescription } from "../../../src/util/commandline/option-parser";
 import {
   getOptionsDescription, getPositionalOptionsDescription, getClassHelpText,
-  shortName, longName, name, defaultValue, required, hasArg, help, position
+  shortName, longName, name, defaultValue, required, hasArg, help, position, 
+  common
 } from "../../../src/util/commandline/option-decorators";
 
 describe("Command line option parsing", function () {
@@ -43,6 +44,7 @@ describe("Command line option parsing", function () {
         @longName("another")
         @hasArg
         @required
+        @common
         public anotherArg: string;
       };
 
@@ -64,6 +66,7 @@ describe("Command line option parsing", function () {
       expect(anotherOpt).to.have.property("longName", "another");
       expect(anotherOpt.required).to.be.true;
       expect(anotherOpt.hasArg).to.be.true;
+      expect(anotherOpt.common).to.be.true;
     });
 
     it("should return all args for base classes", function () {


### PR DESCRIPTION
<img width="1517" alt="screen shot 2017-12-14 at 3 11 11 pm" src="https://user-images.githubusercontent.com/14083050/34020703-8e913938-e0ea-11e7-906f-03ec7ea5017b.png">
