### PR TITLE
[CodePush][Cordova] Update assets manifest file location for release-cordova command

### DIFF
--- a/src/commands/codepush/release-cordova.ts
+++ b/src/commands/codepush/release-cordova.ts
@@ -5,6 +5,7 @@ import { out } from "../../util/interaction";
 import { inspect } from "util";
 import * as chalk from "chalk";
 import * as path from "path";
+import * as fs from "fs";
 import { isValidRange, isValidDeployment } from "./lib/validation-utils";
 import { isValidOS, isValidPlatform, getCordovaOrPhonegapCLI, getCordovaProjectAppVersion } from "./lib/cordova-utils";
 
@@ -93,7 +94,13 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
     if (this.os === "ios") {
       outputFolder = path.join(platformFolder, "www");
     } else if (this.os === "android") {
-      outputFolder = path.join(platformFolder, "assets", "www");
+      // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets                
+      let outputFolderVer7 = path.join(platformFolder, "app", "src", "main", "assets", "www");
+      if (fs.existsSync(outputFolderVer7)) {
+        outputFolder = outputFolderVer7;
+      } else {
+        outputFolder = path.join(platformFolder, "assets", "www");
+      }
     }
 
     return outputFolder;

--- a/src/commands/codepush/release-cordova.ts
+++ b/src/commands/codepush/release-cordova.ts
@@ -95,7 +95,7 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
       outputFolder = path.join(platformFolder, "www");
     } else if (this.os === "android") {
       // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets                
-      let outputFolderVer7 = path.join(platformFolder, "app", "src", "main", "assets", "www");
+      const outputFolderVer7 = path.join(platformFolder, "app", "src", "main", "assets", "www");
       if (fs.existsSync(outputFolderVer7)) {
         outputFolder = outputFolderVer7;
       } else {


### PR DESCRIPTION
Since cordova-android ver7 assets directory location was changed. This PR fixes release-cordova command to use correct assets directory for release.
PR was tested for backward compatibility with previous cordova versions.
Related PR: https://github.com/Microsoft/code-push/pull/548