### PR TITLE
Fix a bug where getReactNativeProjectAppVersion returns undefined

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -179,16 +179,24 @@ export function getReactNativeProjectAppVersion(versionSearchParams: VersionSear
       throw new Error(`Unable to find or read "${appxManifestFileName}" in the "${path.join("windows", projectName)}" folder.`);
     }
 
+    var verStr
     xml2js.parseString(appxManifestContents, (err: Error, parsedAppxManifest: any) => {
       if (err) {
         throw new Error(`Unable to parse the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file, it could be malformed.`);
       }
       try {
-        return parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0];
+        verStr = parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0];
       } catch (e) {
         throw new Error(`Unable to parse the package version from the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file.`);
       }
     });
+
+    // Wait for xml2js.parseString finish.
+    while(true) {
+        if(verStr !== null)
+            break
+    }
+    return Promise.resolve(verStr)
   }
 }
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -174,7 +174,7 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
     var appxManifestFileName: string = "Package.appxmanifest";
     try {
       var appxManifestContainingFolder: string = path.join("windows", projectName);
-      var appxManifestContents: string = fs.readFileSync(path.join(appxManifestContainingFolder, "Package.appxmanifest")).toString();
+      var appxManifestContents: string = fs.readFileSync(path.join(appxManifestContainingFolder, appxManifestFileName)).toString();
     } catch (err) {
       throw new Error(`Unable to find or read "${appxManifestFileName}" in the "${path.join("windows", projectName)}" folder.`);
     }
@@ -186,6 +186,7 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
         }
         try {
           let appVersion: string = parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0];
+          out.text(`Using the target binary version value "${appVersion}" from the "Identity" key in the "${appxManifestFileName}" file.\n`);
           return resolve(appVersion);
         } catch (e) {
           throw new Error(`Unable to parse the package version from the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file.`);

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -185,7 +185,8 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
           throw new Error(`Unable to parse the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file, it could be malformed.`);
         }
         try {
-          resolve(parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0]);
+          let appVersion: string = parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0];
+          return resolve(appVersion);
         } catch (e) {
           throw new Error(`Unable to parse the package version from the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file.`);
         }
@@ -199,20 +200,20 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
   let envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
 
   if (typeof envNodeArgs !== "undefined") {
-    Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));
+      Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));
   }
 
   Array.prototype.push.apply(reactNativeBundleArgs, [
-    path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
-    "--assets-dest", outputFolder,
-    "--bundle-output", path.join(outputFolder, bundleName),
-    "--dev", development,
-    "--entry-file", entryFile,
-    "--platform", platform,
+      path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
+      "--assets-dest", outputFolder,
+      "--bundle-output", path.join(outputFolder, bundleName),
+      "--dev", development,
+      "--entry-file", entryFile,
+      "--platform", platform,
   ]);
 
   if (sourcemapOutput) {
-    reactNativeBundleArgs.push("--sourcemap-output", sourcemapOutput);
+      reactNativeBundleArgs.push("--sourcemap-output", sourcemapOutput);
   }
 
   out.text(chalk.cyan("Running \"react-native bundle\" command:\n"));
@@ -220,21 +221,21 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
   out.text(`node ${reactNativeBundleArgs.join(" ")}`);
 
   return new Promise<void>((resolve, reject) => {
-    reactNativeBundleProcess.stdout.on("data", (data: Buffer) => {
-      out.text(data.toString().trim());
-    });
+      reactNativeBundleProcess.stdout.on("data", (data: Buffer) => {
+        out.text(data.toString().trim());
+      });
 
-    reactNativeBundleProcess.stderr.on("data", (data: Buffer) => {
-      console.error(data.toString().trim());
-    });
+      reactNativeBundleProcess.stderr.on("data", (data: Buffer) => {
+          console.error(data.toString().trim());
+      });
 
-    reactNativeBundleProcess.on("close", (exitCode: number) => {
-      if (exitCode) {
-        reject(new Error(`"react-native bundle" command exited with code ${exitCode}.`));
-      }
+      reactNativeBundleProcess.on("close", (exitCode: number) => {
+          if (exitCode) {
+              reject(new Error(`"react-native bundle" command exited with code ${exitCode}.`));
+          }
 
-      resolve(<void>null);
-    });
+          resolve(<void>null);
+      });
   });
 }
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -178,18 +178,19 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
     } catch (err) {
       throw new Error(`Unable to find or read "${appxManifestFileName}" in the "${path.join("windows", projectName)}" folder.`);
     }
-
     return new Promise<string>((resolve, reject) => {
       xml2js.parseString(appxManifestContents, (err: Error, parsedAppxManifest: any) => {
         if (err) {
-          throw new Error(`Unable to parse the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file, it could be malformed.`);
+          reject(new Error(`Unable to parse the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file, it could be malformed.`));
+          return;
         }
         try {
           let appVersion: string = parsedAppxManifest.Package.Identity[0]["$"].Version.match(/^\d+\.\d+\.\d+/)[0];
           out.text(`Using the target binary version value "${appVersion}" from the "Identity" key in the "${appxManifestFileName}" file.\n`);
           return resolve(appVersion);
         } catch (e) {
-          throw new Error(`Unable to parse the package version from the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file.`);
+          reject(new Error(`Unable to parse the package version from the "${path.join(appxManifestContainingFolder, appxManifestFileName)}" file.`));
+          return;
         }
       });
     });


### PR DESCRIPTION
My appcenter-cli version is 1.0.6. When I run this command for release my React Native Windows app:
```appcenter codepush release-react -a myh/thcs-uwp```
, I got this error message:
```
Detecting windows app version:

Running "react-native bundle" command:

node node_modules\react-native\local-cli\cli.js bundle --assets-dest C:\Users\myh\AppData\Local\Temp\code-push1171128-20424-1lwnbgu.lp5o --bundle-output C:\Users\myh\AppData\Local\Temp\code-push1171128-20424-1lwnbgu.lp5o\index.windows.bundle --dev false --entry-file index.windows.js --platform windows
Scanning folders for symlinks in D:\git\thcs\node_modules (31ms)
Scanning folders for symlinks in D:\git\thcs\node_modules (31ms)
Loading dependency graph, done.
bundle: start
bundle: finish
bundle: Writing bundle output to: C:\Users\myh\AppData\Local\Temp\code-push1171128-20424-1lwnbgu.lp5o\index.windows.bundle
bundle: Done writing bundle output
bundle: Copying 1 asset files
bundle: Done copying assets

Releasing update contents to CodePush:

Error: Invalid binary version(s) for a release.
```
I debug the appcenter by Visual Studio Code and find the return value of getReactNativeProjectAppVersion is undefined in a line in release-react.js:
```this.targetBinaryVersion = yield getReactNativeProjectAppVersion(versionSearchParams);```
I think the bug comes from the call, xml2js.parseString, in react-native-utils.js. Its an async call. The call may not finish before getReactNativeProjectAppVersion returns, so 'undefined' is returned.
Additionally, there is no problem when I codepush the React Native Android app by:
```appcenter codepush release-react -a myh/thcs-android```

After my applying my patch, the codepush command for Windows works now:
```appcenter codepush release-react -a myh/thcs-uwp```