### PR TITLE
UITest: adds ability to specify extra parameters to prepare uitest

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -85,18 +85,6 @@ export abstract class RunTestsCommand extends AppCommand {
     }
   }
 
-  protected fixArrayParameter(input: any): string[]
-  {
-    if (!input) {
-      return [];
-    }
-    else if (typeof input === "string") {
-      return [ input ];
-    }
-
-    return input;
-  }
-
   // Override this if you need to validate options
   protected async validateOptions(): Promise<void> {
   }

--- a/src/commands/test/prepare/uitest.ts
+++ b/src/commands/test/prepare/uitest.ts
@@ -58,8 +58,42 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
   @hasArg
   uiTestToolsDir: string;
 
+  @help(Messages.TestCloud.Arguments.Fixture)
+  @longName("fixture")
+  @hasArg
+  fixture: string[];
+
+  @help(Messages.TestCloud.Arguments.IncludeCategory)
+  @longName("include-category")
+  @hasArg
+  includeCategory: string[];
+
+  @help(Messages.TestCloud.Arguments.ExcludeCategory)
+  @longName("exclude-category")
+  @hasArg
+  excludeCategory: string[];
+
+  @help(Messages.TestCloud.Arguments.NUnitXml)
+  @longName("nunit-xml")
+  @hasArg
+  nunitXml: string;
+
+  @help(Messages.TestCloud.Arguments.TestChunk)
+  @longName("test-chunk")
+  @hasArg
+  testChunk: boolean;
+
+  @help(Messages.TestCloud.Arguments.FixtureChunk)
+  @longName("fixture-chunk")
+  @hasArg
+  fixtureChunk: boolean;
+
   constructor(args: CommandArgs) {
     super(args);
+
+    this.fixture = this.fixArrayParameter(this.fixture);
+    this.includeCategory = this.fixArrayParameter(this.includeCategory);
+    this.excludeCategory = this.fixArrayParameter(this.excludeCategory);
   }
 
   protected async validateOptions(): Promise<void> {
@@ -81,6 +115,12 @@ export default class PrepareUITestCommand extends PrepareTestsCommand {
     preparer.keyAlias = this.keyAlias;
     preparer.keyPassword = this.keyPassword;
     preparer.uiTestToolsDir = this.uiTestToolsDir;
+    preparer.fixture = this.fixture;
+    preparer.includeCategory = this.includeCategory;
+    preparer.excludeCategory = this.excludeCategory;
+    preparer.nunitXml = this.nunitXml;
+    preparer.testChunk = this.testChunk;
+    preparer.fixtureChunk = this.fixtureChunk;
 
     return preparer.prepare();
   }

--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -183,4 +183,16 @@ export class Command {
     const packageJson: any = require(packageJsonPath);
     return packageJson.version;
   }
+
+  protected fixArrayParameter(input: any): string[]
+  {
+    if (!input) {
+      return [];
+    }
+    else if (typeof input === "string") {
+      return [ input ];
+    }
+
+    return input;
+  }
 }


### PR DESCRIPTION
### Motivation
We added the missing parameters to the main `run uitest` method and this makes the equivalent changes when the user calls `prepare` followed by `run manifest`.

We need this to support `--include-category` and `--exclude-category` in the VSTS Task among other client requests.

### Notes
I moved `fixArrayParameter` out to the shared `Command` but please let me know if you'd rather see this moved out somewhere else.