### PR TITLE
Sort builds by id instead of buildNumber

### DIFF
--- a/src/commands/build/branches/show.ts
+++ b/src/commands/build/branches/show.ts
@@ -42,7 +42,7 @@ export default class ShowBranchBuildStatusCommand extends AppCommand {
     }
 
     // Taking last build
-    const lastBuild = _.maxBy(builds, (build) => Number(build.buildNumber));
+    const lastBuild = _.maxBy(builds, (build) => Number(build.id));
 
     debug(`Getting commit info for commit ${lastBuild.sourceVersion}`);
     let commitInfoRequestResponse: ClientResponse<models.CommitDetails[]>;


### PR DESCRIPTION
This is because `buildNumber` can have different formats. It can be similar to build id, but can also be timestamp. If a user switches the format, then sort by `buildNumber` to get the latest build becomes unreliable