### PR TITLE
Feature/profile reads env vars for local

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/util/profile/environments.ts
+++ b/src/util/profile/environments.ts
@@ -1,5 +1,9 @@
 // Management for the current environment.
 
+export const appCenterEndpointEnvVar = "APPCENTER_ENDPOINT";
+export const appCenterLoginEndpointEnvVar = "APPCENTER_LOGIN_ENDPOINT";
+export const appCenterPortalEndpointEnvVar = "APPCENTER_PORTAL_ENDPOINT";
+
 export interface EnvironmentInfo {
   endpoint: string;
   loginEndpoint: string;
@@ -43,11 +47,11 @@ const environmentsData: EnvironmentsFile = {
       portalEndpoint: "https://appcenter.ms",
       description: "Production"
     },
-    testCloudLocalDev: {
-      endpoint: "http://localhost:1700",
-      loginEndpoint: null,
-      portalEndpoint: "http://localhost:8080",
-      description: "Test Cloud local dev box development"
+    local: {
+      endpoint: process.env[appCenterEndpointEnvVar] || "http://localhost:1700",
+      loginEndpoint: process.env[appCenterLoginEndpointEnvVar] || null,
+      portalEndpoint: process.env[appCenterPortalEndpointEnvVar] || "http://localhost:8080",
+      description: "Local Development"
     }
   }
 };


### PR DESCRIPTION
### Motivation

Previously there was a `testCloudLocalDev` environment option with some hardcoded endpoints. I've generalized this environment configuration to read from the `process.env` and renamed it to just `local`. 

The intention is that now a developer could easily specify where `appcenter-cli` should search for endpoints e.g. on their local machine. This is convenient when, e.g., we need to run the portal/api on alternative ports/hostnames. 

Example:
```shell
APPCENTER_PORTAL_ENDPOINT=<local location> APPCENTER_ENDPOINT=<local location> \
appcenter login --env local --debug -u <name> -p <pw>
```