### PR TITLE
[CodePush] fix for --no-duplicate-release-error flag

### DIFF
--- a/src/commands/codepush/lib/legacy-codepush-service-client.ts
+++ b/src/commands/codepush/lib/legacy-codepush-service-client.ts
@@ -45,7 +45,7 @@ export default class LegacyCodePushServiceClient {
           if (httpResponse.statusCode === 201) {
             resolve(<void>null);
           } else {
-            reject(this.getErrorMessage(null, httpResponse));
+            reject({ request: request, response: httpResponse });
             return;
           }
         });


### PR DESCRIPTION
1. implement support for `disable-duplicate-release-error` flag.
2. rename `no-duplicate-release-error` flag to the `disable-duplicate-release-error` because of this issue https://github.com/substack/minimist/issues/123
3. remove `@shortName("d")` for `description` in `promote` command due to conflict with `destination-deployment-name` argument
4. rename `dest-deployment-name` to `destination-deployment-name` - avoid of using abbrivations