### PR TITLE
Update npm scripts to do autorest for non prod environments correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     "test": "mocha --compilers ts:ts-node/register --recursive ./test/**/*-test.[tj]s",
     "watch-test": "mocha --compilers ts:ts-node/register --recursive ./test/**/*-test.[tj]s --watch",
     "autorest:clean": "rimraf src/util/apis/generated",
-    "autorest:download-swagger": "node scripts/download-swagger.js",
-    "autorest:fixup-swagger": "node scripts/fixup-swagger.js",
-    "autorest:generate": "autorest swagger/readme.md",
-    "autorest": "npm run autorest:clean && npm run autorest:download-swagger && npm run autorest:fixup-swagger && npm run autorest:generate",
+    "autorest": "npm run autorest:clean && node scripts/autorest.js",
     "clean": "gulp clean",
     "prepublishOnly": "gulp prepublish",
     "download-swagger": "gulp download-swagger"

--- a/scripts/autorest.js
+++ b/scripts/autorest.js
@@ -1,0 +1,45 @@
+const _ = require('lodash')
+const childProcess = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+
+const downloadSwagger = require('./download-swagger')
+const { fixupRawSwagger, rawSwaggerPath, fixedSwaggerPath } = require('./fixup-swagger')
+
+const args = require('minimist')(process.argv.slice(2), downloadSwagger.parseOpts)
+
+function runAutorest() {
+  let autorestScript = 'autorest'
+  if (process.platform === 'win32') {
+    autorestScript += '.cmd'
+  }
+
+  const configFilePath = path.join(__dirname, '..', 'swagger', 'readme.md')
+
+  console.log(`Running ${autorestScript} "${configFilePath}"`)
+
+  return new Promise((resolve, reject) => {
+    let arp = childProcess.spawn(
+      path.join(__dirname, '..', 'node_modules', '.bin', autorestScript),
+      [ configFilePath ],
+      { cwd: path.join(__dirname, '..') }
+    )
+
+  	arp.stdout.on('data', (data) => console.log(data.toString()))
+  	arp.stderr.on('error', (data) => console.error(data.toString()))
+  	arp.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject();
+      }
+    })
+  })
+}
+
+downloadSwagger.downloadSwagger(args.env, args.version)
+  .then(() => fixupRawSwagger(rawSwaggerPath, fixedSwaggerPath))
+  .then(() => runAutorest())
+  .then(() => console.log(`Swagger update complete`))
+  .catch((err) => console.log(`Autorest process failed, ${err}`))

--- a/scripts/download-swagger.js
+++ b/scripts/download-swagger.js
@@ -63,9 +63,8 @@ function downloadSwagger(environment, version) {
   });
 }
 
-downloadSwagger(args.env, args.version)
-  .then(() => console.log('Download complete'))
-  .catch((err) => {
-    console.error(`Download failed: ${err.message}`);
-    process.exit(-1);
-  });
+module.exports = {
+  downloadSwagger,
+  defaultVersion,
+  parseOpts
+};

--- a/scripts/fixup-swagger.js
+++ b/scripts/fixup-swagger.js
@@ -123,6 +123,8 @@ function setOperationToFile(operation) {
   }
 }
 
-fixupRawSwagger(
-  path.join(__dirname, '../swagger/bifrost.swagger.before.json'),
-  path.join(__dirname, '../swagger/bifrost.swagger.json'));
+module.exports = {
+  fixupRawSwagger,
+  rawSwaggerPath: path.join(__dirname, '..', 'swagger', 'bifrost.swagger.before.json'),
+  fixedSwaggerPath: path.join(__dirname, '..', 'swagger', 'bifrost.swagger.json')
+};


### PR DESCRIPTION
The --env switch wasn't being properly passed to all the stages of the autorest command.
