### PR TITLE
Use correct format for calabash test params

### DIFF
--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -64,7 +64,7 @@ export class CalabashPreparer {
     }
 
     if (this.testParameters && this.testParameters.length > 0) {
-      command += this.generateTestParameterArgs();
+      command += ` --test-parameters ${this.generateTestParameterArgs()}`;
     }
 
     return command;
@@ -72,11 +72,7 @@ export class CalabashPreparer {
 
   private generateTestParameterArgs(): string {
     let result: string = "";
-    this.testParameters.forEach(p => {
-      let parsedParameter = parseTestParameter(p);
-      result += ` --test-parameters "${parsedParameter.key}:${parsedParameter.value}"`;
-    });
-    return result;
+    return this.testParameters.map(parseTestParameter).map(p => `"${p.key}:${p.value}"`).join(" ");
   }
 
   /*

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -64,7 +64,7 @@ export class CalabashPreparer {
     }
 
     if (this.testParameters && this.testParameters.length > 0) {
-      command += ` --test-params ${this.generateTestParameterArgs()}`;
+      command += this.generateTestParameterArgs();
     }
 
     return command;
@@ -72,20 +72,10 @@ export class CalabashPreparer {
 
   private generateTestParameterArgs(): string {
     let result: string = "";
-
-    if (this.testParameters) {
-      this.testParameters.forEach(p => {
-        let parsedParameter = parseTestParameter(p);
-        if (result != "") {
-          result += ",";
-        }
-        result += `${parsedParameter.key}:`;
-        if (parsedParameter.value != null) {
-          result += `${parsedParameter.value}`;
-        }
-      });
-    }
-
+    this.testParameters.forEach(p => {
+      let parsedParameter = parseTestParameter(p);
+      result += ` --test-parameters "${parsedParameter.key}:${parsedParameter.value}"`;
+    });
     return result;
   }
 

--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -46,6 +46,9 @@ export class PrepareTestsCommand extends Command {
   protected async validateOptions(): Promise<void> {
   }
 
+  // TODO: There is technical debt here.
+  // There is a lot of confusion and even duplicated code with respect to test params,
+  // included files and responsibility of prepare vs run.
   public async runNoClient(): Promise<CommandResult> {
     try {
       await this.validateOptions();

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -88,7 +88,9 @@ export abstract class RunTestsCommand extends AppCommand {
   // Override this if you need to validate options
   protected async validateOptions(): Promise<void> {
   }
-
+  // TODO: There is technical debt here.
+  // There is a lot of confusion and even duplicated code with respect to test params,
+  // included files and responsibility of prepare vs run.
   public async run(client: AppCenterClient, portalBaseUrl: string): Promise<CommandResult> {
     if (this.isAppPathRquired && !this.appPath) {
       throw new Error("Argument --app-path is required");


### PR DESCRIPTION
*PR Updated after discovering some technical debt.*

Test parameters are passed incorrectly when preparing calabash tests.

 `--test-parameter "a=b"` is passed as `--test-params` but it should be passed as `--test-parameters` as you can see from the `xamarin-test-cloud` gem:

```
test-cloud help prepare
...
  -params, [--test-parameters=key:value]               # Example: -params username:nat@xamarin.com password:xamarin)
...
```
Also they are formatted incorrectly.

This PR fixes the problems.

With this change, they are passed as
```
test-cloud prepare XTCAndroidSample.apk \
 --artifacts-dir /var/folders/hs/ycgt048163132zqg0mh_1r1h0000gn/T/appcenter-upload11814-29672-gm1jvu.bp70h \
 --workspace "." \
 --test-parameters "pipeline:calabash-android-in-container" "isolated:true"
```
In addition, this PR cleans up some confusing code `addIncludedFilesAndTestParametersToManifest ` in run-tests-command.ts was lying. It does not touch test params.  This however is not needed as the upload phase will add the test parameters. So I updated the method to be named: `addIncludedFilesToManifestAndCopyToArtifactsDir`.


Current experience with appcenter version 1.0.9:
```
appcenter test run calabash --app "My-Organization/Test-Cloud-Sample-App" --devices 1ef14dbe --app-path XTCAndroidSample.apk --test-series "master" --locale "en_US" --test-parameter "a=b" --test-parameter "c=d" --project-dir .
| Preparing tests... ERROR: "test-cloud prepare" was called with arguments ["XTCAndroidSample.apk", "--test-params", "a:b,c:d"]
Usage: "test-cloud prepare <APP> --artifacts-dir=ARTIFACTS-DIR"

Preparing tests... failed.
Error: Cannot prepare Calabash artifacts. Returning exit code 70.

Further error details: For help, please send both the reported error above and the following environment information to us by going to https://appcenter.ms/apps and starting a new conversation (using the icon in the bottom right corner of the screen)

        Environment: darwin
        App Upload Id: My-Organization/Test-Cloud-Sample-App
        Timestamp: 1517758803889
        Operation: RunCalabashTestsCommand
        Exit Code: 70
        User Email: kakrukow@microsoft.com
        User Name: karl.krukow
        User Id: 5db91bbe-dc92-411b-9713-0e15eaaa99bd
```

Experience with this change:
```
ts-node src/index.ts test run calabash --app "My-Organization/Test-Cloud-Sample-App" --devices 1ef14dbe --app-path /Users/krukow/code/test-cloud-test-apps/XTCAndroidSampleProject/test-calabash-cucumber-2/XTCAndroidSample.apk --test-series "master" --locale "en_US" --test-parameter "a=b" --test-parameter "c=d" --project-dir /Users/krukow/code/test-cloud-test-apps/XTCAndroidSampleProject/test-calabash-cucumber-2
- Preparing tests...
...
- Preparing tests...
### Preparing the Artifact Directory ###

Copied files to:
  /var/folders/hs/ycgt048163132zqg0mh_1r1h0000gn/T/appcenter-upload11814-29778-bxge6g.rk3u7

Wrote upload manifest to:
  /var/folders/hs/ycgt048163132zqg0mh_1r1h0000gn/T/appcenter-upload11814-29778-bxge6g.rk3u7/manifest.json

Preparing tests... done.
Validating arguments... done.
Creating new test run... done.
Validating application file... done.
Uploading files... done.
Starting test run... done.
...
```

and parameters are correctly passed to Test Cloud:

```
"args"=>[{"test_parameters"=>{"a"=>"b", "c"=>"d", ....}}..]
```