### PR TITLE
Fix/include files

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -190,7 +190,7 @@ export abstract class RunTestsCommand extends AppCommand {
 
     for (let i = 0; i < includedFiles.length; i++) {
       let includedFile = includedFiles[i];
-      let copyTarget = path.join(this.artifactsDir, includedFile.targetPath);
+      let copyTarget = path.join(path.dirname(manifestPath), includedFile.targetPath);
       await pfs.cp(includedFile.sourcePath, copyTarget);
       manifest.files.push(includedFile.targetPath);
     }

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -181,7 +181,7 @@ export abstract class RunTestsCommand extends AppCommand {
   }
 
   private async addIncludedFilesToManifestAndCopyToArtifactsDir(manifestPath: string): Promise<void> {
-    if (this.include) {
+    if (!this.include) {
       return;
     }
     let manifestJson = await pfs.readFile(manifestPath, "utf8");


### PR DESCRIPTION
There was a (stupid) inversion of logic handling included files causing files specified with `--include` to not be uploaded to Test Cloud.

This pull request fixes that.

@christav could you review and release?