### PR TITLE
Fix incorrect test due to typo

### DIFF
--- a/test/commands/test/lib/appium-preparer-test.ts
+++ b/test/commands/test/lib/appium-preparer-test.ts
@@ -13,7 +13,7 @@ function createValidBuildDirSpec(): fsLayout.IDirSpec {
     "pom.xml": '<?xml version="1.0" encoding="utf-8"><foo></foo>',
     "dependency-jars": { },
     "test-classes": {
-      "test.classs": "Fake *.class file"
+      "test.class": "Fake *.class file"
     }
   };
 };


### PR DESCRIPTION
Typo in test caused false positive on test failure. With this change:  129 passing (674ms).