### PR TITLE
Create long path if it doesn't exist

### DIFF
--- a/src/util/misc/promisfied-fs.ts
+++ b/src/util/misc/promisfied-fs.ts
@@ -72,7 +72,7 @@ export function mkdirp (...args: any[]): Promise<string> {
       } else {
         resolve(made);
       }
-    }]));    
+    }]));
   });
 }
 
@@ -92,7 +92,7 @@ export async function cp(source: string, target: string): Promise<void> {
 
 export async function cpDir(source: string, target: string): Promise<void> {
   if (!await exists(target)) {
-    await mkdir(target);
+    createLongPath(target);
   }
   let files = await readdir(source);
 
@@ -106,6 +106,10 @@ export async function cpDir(source: string, target: string): Promise<void> {
 
 export function cpFile(source: string, target: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
+    let targetFolder = path.dirname(target);
+    if(!fs.existsSync(targetFolder)) {
+      createLongPath(targetFolder);
+    }
     let sourceStream = fs.createReadStream(source);
     let targetStream = fs.createWriteStream(target);
 
@@ -175,7 +179,7 @@ export async function walk(dir: string): Promise<string[]> {
 
 async function pathExists(path: string, isFile: boolean): Promise<boolean> {
   let stats: fs.Stats = null;
-  
+
   try {
     stats = await stat(path);
   }
@@ -184,6 +188,21 @@ async function pathExists(path: string, isFile: boolean): Promise<boolean> {
   }
 
   return isFile === stats.isFile();
+}
+
+function createLongPath(target: string) {
+  let targetFolder: string = target;
+  let notExistsFolder: string[] = [];
+
+  while(!fs.existsSync(targetFolder)) {
+    notExistsFolder.push(path.basename(targetFolder));
+    targetFolder = path.resolve(targetFolder, "..");
+  }
+
+  notExistsFolder.reverse().forEach(element => {
+    targetFolder = path.resolve(targetFolder,element);
+    fs.mkdirSync(targetFolder);
+  });
 }
 
 function callFs(func: (...args: any[]) => void, ...args: any[]): Promise<any[]> {


### PR DESCRIPTION
My PR fixes all cases which marked as `Doesn't work`
```
"args": [
        // Add your Mobile Center CLI command
        "test",
        "run",
        "uitest",
        "--devices", "%deviceId%",
        "--build-dir", "%pathToBuildDir%",
        "--app-path", "%pathToApk%",
        "--app", "%app%",
        "--include", "config.json", // Works
        "--include", "something/config.json", // Doesn't work
        "--include", "1/2/3/4/5/config.json", // Doesn't work
        "--include", "1/2/3/4/5/6" // Doesn't work
      ]
```