### PR TITLE
Make profile directory configurable

### DIFF
--- a/src/util/misc/get-profile-dir.ts
+++ b/src/util/misc/get-profile-dir.ts
@@ -7,6 +7,10 @@ import { profileDirName, oldProfileDirName, profileFile } from "./constants";
 const debug = require("debug")("appcenter-cli:util:misc:get-profile-dir");
 
 export function getProfileDir(): string {
+  if (typeof process.env.APPCENTER_PROFILE_DIR === 'string') {
+    return process.env.APPCENTER_PROFILE_DIR;
+  }
+
   const profileDir = path.join(getProfileDirParent(), profileDirName);
   const oldProfileDir = path.join(getProfileDirParent(), oldProfileDirName);
   if (!existsSync(profileDir) && existsSync(oldProfileDir)) {


### PR DESCRIPTION
I'd like to `appcenter-cli` from Jenkins to automate CodePush deploy.
But it fails because of permission of `$HOME` (`/var/lib/jenkins`).

So I made the profile directory configurable with environment variable `APPCENTER_PROFILE_DIR`.

I think it's helpful to automate some tasks besides CodePush.
What do you think?