### PR TITLE
Distribution release release version undefined

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -80,12 +80,15 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Retrieving the release");
     const releaseDetails = await this.getDistributeRelease(client, app, releaseId);
 
-    if (_.isNull(distributionGroupUsersCount)) {
-      out.text((rd) => `Release ${rd.shortVersion} (${rd.version}) was successfully released to ${this.distributionGroup}`, releaseDetails);
+    if (releaseDetails) {
+      if (_.isNull(distributionGroupUsersCount)) {
+        out.text((rd) => `Release ${rd.shortVersion} (${rd.version}) was successfully released to ${this.distributionGroup}`, releaseDetails);
+      } else {
+        out.text((rd) => `Release ${rd.shortVersion} (${rd.version}) was successfully released to ${distributionGroupUsersCount} testers in ${this.distributionGroup}`, releaseDetails);
+      }
     } else {
-      out.text((rd) => `Release ${rd.shortVersion} (${rd.version}) was successfully released to ${distributionGroupUsersCount} testers in ${this.distributionGroup}`, releaseDetails);
+      out.text(`Release was successfully released.`);
     }
-
     return success();
   }
 
@@ -238,7 +241,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
       } else if (error === 404) {
         throw failure(ErrorCodes.Exception, `The release ${releaseId} can't be found`);        
       } else {
-        throw failure(ErrorCodes.Exception, `failed to retrieve the release ${releaseId}`);
+        return null;
       }
     }
 

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -75,7 +75,10 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const releaseId = this.extractReleaseId(releaseUrl);
 
     debug("Distributing the release");
-    const releaseDetails = await this.distributeRelease(client, app, releaseId, releaseNotesString);
+    await this.distributeRelease(client, app, releaseId, releaseNotesString);
+
+    debug("Retrieving the release");
+    const releaseDetails = await this.getDistributeRelease(client, app, releaseId);
 
     if (_.isNull(distributionGroupUsersCount)) {
       out.text((rd) => `Release ${rd.shortVersion} (${rd.version}) was successfully released to ${this.distributionGroup}`, releaseDetails);
@@ -221,6 +224,25 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const releaseId = Number(_(releaseUrl).split("/").last());
     console.assert(Number.isSafeInteger(releaseId) && releaseId > 0, `API returned unexpected release URL: ${releaseUrl}`);
     return releaseId;
+  }
+
+  private async getDistributeRelease(client: AppCenterClient, app: DefaultApp, releaseId: number): Promise<models.ReleaseDetailsResponse> {
+    let releaseRequestResponse: ClientResponse<models.ReleaseDetailsResponse>;
+    try {
+      releaseRequestResponse = await out.progress(`Retrieving the release...`, 
+        clientRequest<models.ReleaseDetailsResponse>(async (cb) => client.releases.getLatestByUser(releaseId.toString(), 
+          app.ownerName, app.appName, cb)));
+    } catch (error) {
+      if (error === 400) {
+        throw failure(ErrorCodes.Exception, "release_id is not an integer or the string latest");
+      } else if (error === 404) {
+        throw failure(ErrorCodes.Exception, `The release ${releaseId} can't be found`);        
+      } else {
+        throw failure(ErrorCodes.Exception, `failed to retrieve the release ${releaseId}`);
+      }
+    }
+
+    return releaseRequestResponse.result;
   }
 
   private async distributeRelease(client: AppCenterClient, app: DefaultApp, releaseId: number, releaseNotesString: string): Promise<models.ReleaseDetailsResponse> {


### PR DESCRIPTION
When user distributes a release through CLI, the release version number is not shown properly. This PR fixed this issue: 
<img width="819" alt="screen shot 2018-02-12 at 2 17 48 pm" src="https://user-images.githubusercontent.com/174866/36122937-fa77a472-0fff-11e8-884b-7d606e26db9a.png">

Above image shows the difference before and after the change. 
