### PR TITLE
Fix the logic to get server URL

### DIFF
--- a/src/commands/codepush/lib/environment.ts
+++ b/src/commands/codepush/lib/environment.ts
@@ -39,6 +39,6 @@ const codePushEnvironmentsData: EnvironmentsFile = {
   }
 };
 
-export function environments(environmentName: string = codePushEnvironmentsData.defaultEnvironment): CodePushEnvironmentInfo {
+export function environments(environmentName: string = codePushEnvironmentsData.defaultEnvironment): CodePushEnvironmentInfo | undefined {
   return codePushEnvironmentsData.environments[environmentName];
 }

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -103,7 +103,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
 
     try {
       const app = this.app;
-      const serverUrl = environments(this.environmentName || getUser().environment).managementEndpoint;
+      const serverUrl = this.getServerUrl();
       const token = this.token || await getUser().accessToken;
       
       await out.progress("Creating CodePush release...",  this.releaseStrategy.release(client, app, this.deploymentName, updateContentsZipPath, {
@@ -131,6 +131,22 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       }
     } finally {
       await pfs.rmDir(updateContentsZipPath);
+    }
+  }
+
+  private getServerUrl(): string | undefined {
+    const environment = environments(this.getEnvironmentName());
+    return environment && environment.managementEndpoint;
+  }
+
+  private getEnvironmentName(): string | undefined {
+    if (this.environmentName) {
+      return this.environmentName;
+    }
+
+    const user = getUser();
+    if (user) {
+      return user.environment;
     }
   }
 

--- a/src/util/profile/profile.ts
+++ b/src/util/profile/profile.ts
@@ -130,14 +130,14 @@ export function toDefaultApp(app: string): DefaultApp {
   return null;
 }
 
-let currentProfile: Profile = null;
+let currentProfile: Profile | null = null;
 
 function getProfileFilename(): string {
   const profileDir = getProfileDir();
   return path.join(profileDir, profileFile);
 }
 
-function loadProfile(): Profile {
+function loadProfile(): Profile | null {
   const profilePath = getProfileFilename();
   debug(`Loading profile from ${profilePath}`);
   if (!fileExistsSync(profilePath)) {
@@ -151,7 +151,7 @@ function loadProfile(): Profile {
   return new ProfileImpl(profile);
 }
 
-export function getUser(): Profile {
+export function getUser(): Profile | null {
   debug("Getting current user from profile");
   if (!currentProfile) {
     debug("No current user, loading from file");


### PR DESCRIPTION
## Problem

`appcenter codepush release-react` fails with an error in a case:

```
Releasing update contents to CodePush:

Error: TypeError: Cannot read property 'environment' of null
```

## Steps to Reproduce

1. Make sure that `appcenter-cli` is logged out
1. Run `appcenter codepush release-react` with `--token` and without `--env`

## Root Cause

This is because `getUser()` does not always return a `Profile`.
It returns `null` when there is no `profile.json` in `~/.appcenter-cli` (see the line 145):
https://github.com/Microsoft/appcenter-cli/blob/d93908f5ed9e8523e020473f23b63c8c437beb2b/src/util/profile/profile.ts#L140-L161

In that case, `getUser().environement` throws the error:

https://github.com/Microsoft/appcenter-cli/blob/d93908f5ed9e8523e020473f23b63c8c437beb2b/src/commands/codepush/lib/release-command-skeleton.ts#L106

## What I Did

I added `getServerUrl()` method to do it correctly.

* If `--env` is specified, it returns the URL of the specified environment
* If a `Profile` exists (in `~/.appcenter-cli/profile.json`), it returns the URL of the the environment specified in `profile.environment`
  * If not, it returns the URL of `prod` env (as it's `defaultEnvironment`)

I also did some improvements for type definitions.