### PR TITLE
Fix token deletion on logout

### DIFF
--- a/src/commands/lib/logout.ts
+++ b/src/commands/lib/logout.ts
@@ -20,7 +20,7 @@ async function performLogout(client: AppCenterClient, user: Profile): Promise<vo
           clientRequest(async cb => {
             try {
               tokenId = await user.accessTokenId;
-              if (!tokenId) {
+              if (!tokenId || tokenId === "null") {
                 tokenId = "current";
               }
               debug(`Attempting to delete token id ${tokenId} off server`);

--- a/src/util/token-store/osx/osx-token-store.ts
+++ b/src/util/token-store/osx/osx-token-store.ts
@@ -112,9 +112,10 @@ export class OsxTokenStore implements TokenStore {
       "-D", "appcenter cli password",
       "-s", serviceName,
       "-w", value.token,
-      "-G", value.id,
       "-U"
     ];
+    
+    if (value.id) { args.push("-G", value.id) }
 
     return new Promise<void>((resolve, reject) => {
       childProcess.execFile(securityPath, args, function (err, stdout, stderr) {

--- a/test/util/token-store/osx-keychain-parser-test.ts
+++ b/test/util/token-store/osx-keychain-parser-test.ts
@@ -169,7 +169,7 @@ describe('security tool output parsing', function () {
   });
 });
 
-describe('storing data in keychain', function () {
+describe('storing complete data in keychain', function () {
   if (os.platform() !== 'darwin') {
     console.log('These tests only run on Mac OSX');
     return;
@@ -199,6 +199,39 @@ describe('storing data in keychain', function () {
     expect(entry).to.be.not.null;
     expect(entry.key).to.equal(testUser);
     expect(entry.accessToken.id).to.equal(testTokenId);
+    expect(entry.accessToken.token).to.equal(testPassword);
+  });
+});
+
+describe('storing data without a tokenId in keychain', function () {
+  if (os.platform() !== 'darwin') {
+    console.log('These tests only run on Mac OSX');
+    return;
+  }
+
+  const keychain = tokenStore.createOsxTokenStore();
+
+  const parseResults: any[] = [];
+  const testUser = "appcenter-user";
+  const testPassword = "Sekret!";
+
+  before(() => {
+    return keychain.set(testUser, { id: null, token: testPassword });
+  });
+
+  after(() => keychain.remove(testUser));
+
+  it('should have at least one item', async function (): Promise<void> {
+    const c = await (keychain.list() as any).count().toPromise();
+    expect(c).to.be.above(0);
+  });
+
+  it('should have expected entry', async function (): Promise<void> {
+    const entry: TokenEntry = await keychain.get(testUser);
+    console.log(`Entry is ${inspect(entry)}`);
+    expect(entry).to.be.not.null;
+    expect(entry.key).to.equal(testUser);
+    expect(entry.accessToken.id).to.equal(undefined);
     expect(entry.accessToken.token).to.equal(testPassword);
   });
 });


### PR DESCRIPTION
Previously, `OsxTokenStore` saved `"null"` as a string when `tokenId` was missing after login (which expectedly happens when using the interactive login flow). `"null"` is truthy so the code path for dealing with missing token IDs during logout was never entered.

This PR fixes both saving of tokens  for the future and adds backwards compatibility for existing, "broken" tokens in users' keychains.