### PR TITLE
Fix the error Cannot read property 'vstsIdVariable' of undefined

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -109,10 +109,11 @@ export abstract class RunTestsCommand extends AppCommand {
         await this.addIncludedFilesToManifestAndCopyToArtifactsDir(manifestPath);
         let testRun = await this.uploadAndStart(client, manifestPath, portalBaseUrl);
 
+        let vstsIdVariable = this.vstsIdVariable;
         this.streamingOutput.text(function (testRun){
           let report: string = `Test run id: "${testRun.testRunId}"` + os.EOL;
-          if(this.vstsIdVariable) {
-            report = `##vso[task.setvariable variable=${this.vstsIdVariable}]"${testRun.testRunId}"` + os.EOL;
+          if(vstsIdVariable) {
+            report = `##vso[task.setvariable variable=${vstsIdVariable}]"${testRun.testRunId}"` + os.EOL;
           }
           report += "Accepted devices: " + os.EOL;
           testRun.acceptedDevices.map(item => `  - ${item}`).forEach(text => report+=text + os.EOL);


### PR DESCRIPTION
> Preparing tests... done.
Validating arguments... done.
Creating new test run... done.
Validating application file... done.
Uploading files... done.
Starting test run... done.
Error: Cannot read property 'vstsIdVariable' of undefined

It happens for any test run because of incorrect context.