### PR TITLE
Wrong android output directory detection fixed

### DIFF
--- a/src/commands/codepush/release-cordova.ts
+++ b/src/commands/codepush/release-cordova.ts
@@ -65,7 +65,6 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
       return failure(ErrorCodes.InvalidParameter, "Invalid binary version(s) for a release.");
     }
 
-    this.updateContentsPath = this.getOutputFolder();
     const cordovaCommand: string = this.getCordovaCommand();
 
     try {
@@ -73,13 +72,20 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
     } catch (e) {
       return failure(ErrorCodes.Exception, `Unable to ${cordovaCommand} project. Please ensure that either the Cordova or PhoneGap CLI is installed.`);
     }
-
+    
     out.text(chalk.cyan(`Running "${cordovaCLI} ${cordovaCommand}" command:\n`));
     try {
       execSync([cordovaCLI, cordovaCommand, this.os, "--verbose"].join(" "), { stdio: "inherit" });
     } catch (error) {
       debug(`Failed to release a CodePush update - ${inspect(error)}`);
       return failure(ErrorCodes.Exception, `Unable to ${cordovaCommand} project. Please ensure that the CWD represents a Cordova project and that the "${this.os}" platform was added by running "${cordovaCLI} platform add ${this.os}".`);
+    }
+
+    try {
+      this.updateContentsPath = this.getOutputFolder();
+    } catch (error) {
+      debug(`Failed to release a CodePush update - ${inspect(error)}`);
+      return failure(ErrorCodes.Exception, `No output folder found. Please ensure that the CWD represents a Cordova project and that the "${this.os}" platform was added by running "${cordovaCLI} platform add ${this.os}".`);
     }
 
     out.text(chalk.cyan("\nReleasing update contents to CodePush:\n"));
@@ -92,18 +98,18 @@ export default class CodePushReleaseCordovaCommand extends CodePushReleaseComman
     let outputFolder: string;
 
     if (this.os === "ios") {
-      outputFolder = path.join(platformFolder, "www");
+      return path.join(platformFolder, "www");
     } else if (this.os === "android") {
-      // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets                
+      // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets
       const outputFolderVer7 = path.join(platformFolder, "app", "src", "main", "assets", "www");
+      const outputFolderPre7 = path.join(platformFolder, "assets", "www");
       if (fs.existsSync(outputFolderVer7)) {
-        outputFolder = outputFolderVer7;
-      } else {
-        outputFolder = path.join(platformFolder, "assets", "www");
+        return outputFolderVer7;
+      } else if (fs.existsSync(outputFolderPre7)) {
+        return outputFolderPre7;
       }
     }
-
-    return outputFolder;
+    throw new Error(`${this.os} output folder does not exists`);
   }
 
   private getCordovaCommand(): string {


### PR DESCRIPTION
When you run `appcenter codepush release-cordova` before you have run `cordova platform add` the wrong output folder is detected under `android`. This pull request moves the detection after the `cordova build` command. In newer versions of the `cordova-cli` the missing platform is automatically added, so a manuell execution of `cordova platform add` is not needed.

I also improved the `getOutputFolder` function in that way that when no output folder at all could be detected an error is presented to the user.