### PR TITLE
Windows EPERM: Warn and don't bail on failed cleanup

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -218,7 +218,7 @@ export abstract class RunTestsCommand extends AppCommand {
 
   protected async cleanupArtifactsDir(artifactsDir: string): Promise<void> {
     await pfs.rmDir(artifactsDir, true).catch(function(err){
-      console.warn(`Error ${err} while cleaning up artifacts directory ${artifactsDir}. Continuing without cleanup.`);
+      console.warn(`Error ${err} while cleaning up artifacts directory ${artifactsDir}. This is often due to files being locked or in use. Please check your virus scan settings and any local security policies you might have in place for this directory. Continuing without cleanup.`);
     });
   }
 

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -217,7 +217,9 @@ export abstract class RunTestsCommand extends AppCommand {
   }
 
   protected async cleanupArtifactsDir(artifactsDir: string): Promise<void> {
-    await pfs.rmDir(artifactsDir, true);
+    await pfs.rmDir(artifactsDir, true).catch(function(err){
+      console.warn(`Error ${err} while cleaning up artifacts directory ${artifactsDir}. Continuing without cleanup.`);
+    });
   }
 
   private artifactsDir: string;

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -218,7 +218,7 @@ export abstract class RunTestsCommand extends AppCommand {
 
   protected async cleanupArtifactsDir(artifactsDir: string): Promise<void> {
     await pfs.rmDir(artifactsDir, true).catch(function(err){
-      console.warn(`Error ${err} while cleaning up artifacts directory ${artifactsDir}. This is often due to files being locked or in use. Please check your virus scan settings and any local security policies you might have in place for this directory. Continuing without cleanup.`);
+      console.warn(`${err} while cleaning up artifacts directory ${artifactsDir}. This is often due to files being locked or in use. Please check your virus scan settings and any local security policies you might have in place for this directory. Continuing without cleanup.`);
     });
   }
 


### PR DESCRIPTION
We've observed errors like:

```
Error: EPERM: operation not permitted, unlink 'C:\BuildAgent\temp\buildTmp\appcenter-upload118115-6800-1ohlguf.j77hk\AndroidTestServer.apk'
```

particularly on Windows. 

This should not cause the CLI to exit, but rather it should issue a warning.