### PR TITLE
Add error message if server message is empty

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -182,6 +182,9 @@ export abstract class RunTestsCommand extends AppCommand {
       }
       else
       {
+        if(!err.message) {
+          err.message = "Could not start your tests. Maybe your subscription has expired.";
+        }
         message = `${err.message}${os.EOL}${os.EOL}${helpMessage}`;
       }
 


### PR DESCRIPTION
Print an useful error message instead of an empty one.

For some reason server side returns the empty error message. It has been replaced by a general message which says "Could not start your tests. Maybe your subscription has expired."