### PR TITLE
Make sure file token directory exists always.

### DIFF
--- a/src/util/token-store/file/file-token-store.ts
+++ b/src/util/token-store/file/file-token-store.ts
@@ -7,6 +7,7 @@
 //
 
 import * as fs from "fs";
+import * as path from "path";
 import * as rx from "rx-lite";
 import { toPairs } from "lodash";
 
@@ -58,6 +59,15 @@ export class FileTokenStore implements TokenStore {
   private loadTokenStoreCache(): void {
     if (this.tokenStoreCache === null) {
       debug(`Loading token store cache from file ${this.filePath}`);
+      // Ensure directory exists
+      try {
+        fs.mkdirSync(path.dirname(this.filePath));
+      } catch (err) {
+        if (err.code !== "EEXIST") {
+          debug(`Unable to create token store cache directory: ${err.message}`);
+          throw err;
+        }
+      }
       try {
         this.tokenStoreCache = JSON.parse(fs.readFileSync(this.filePath, "utf8"));
         debug(`Token store loaded from file`);

--- a/test/util/token-store/file-store-test.ts
+++ b/test/util/token-store/file-store-test.ts
@@ -4,11 +4,14 @@
 
 import { expect } from "chai";
 import * as fs from "fs";
+import * as path from "path";
+import * as rimraf from "rimraf";
 import * as temp from "temp";
 
 // Turn on tracking to make sure files are cleaned up.
 temp.track();
 
+import { fileExistsSync } from "../../../src/util/misc/fs-helper";
 import { TokenEntry } from "../../../src/util/token-store/token-store";
 import { createFileTokenStore, FileTokenStore } from "../../../src/util/token-store/file/file-token-store";
 
@@ -17,6 +20,26 @@ describe("File token store", function () {
     const storePath = temp.path("appcenter-file-cache-test");
     const store = createFileTokenStore(storePath) as FileTokenStore;
     expect(store.getStoreFilePath()).to.equal(storePath);
+  });
+
+  describe("when directory does not exist", function () {
+    let storeParentPath: string;
+
+    before(function () {
+      storeParentPath = temp.path("appcenter-file-cache-test");
+      fs.mkdirSync(storeParentPath);
+    });
+
+    after(function () {
+      rimraf.sync(storeParentPath);
+    });
+
+    it("should create directory for token file", function () {
+      const storePath = path.join(storeParentPath, "subdir", "token-file");
+      const store = createFileTokenStore(storePath) as FileTokenStore;
+      store.set("user1", { id: "123", token: "token1" });
+      expect(fileExistsSync(storePath)).to.be.true;
+    });
   });
 
   describe("when storing values", function () {


### PR DESCRIPTION
Cases exist where file token store doesn't have a directory to write to, so try and create it before accessing.