### PR TITLE
Feature/remove shared runtime check

### DIFF
--- a/src/commands/test/lib/app-validator.ts
+++ b/src/commands/test/lib/app-validator.ts
@@ -1,7 +1,4 @@
 import * as path from "path";
-import * as JsZip from "jszip";
-import * as _ from "lodash";
-import * as Pfs from "../../../util/misc/promisfied-fs";
 
 export class AppValidator {
   private appPath: string;
@@ -19,12 +16,7 @@ export class AppValidator {
   }
 
   public async validate() {
-    if (this.isAndroidApp()) {
-      if (await this.usesSharedRuntime()) {
-        throw new Error("Shared runtime apps are not supported yet.\
-Your application needs to be compiled for release.");
-      }
-    } else if (!this.isIosApp()) {
+    if (!(this.isIosApp() || this.isAndroidApp())) {
       throw new Error("The application file must be either Android or iOS application");
     }
   }
@@ -35,18 +27,5 @@ Your application needs to be compiled for release.");
 
   public isAndroidApp(): boolean {
     return path.extname(this.appPath) === ".apk";
-  }
-
-  public async usesSharedRuntime(): Promise<boolean> {
-    const zipArchive = await Pfs.readFile(this.appPath);
-    const zip = await new JsZip().loadAsync(zipArchive);
-
-    const entries = Object.getOwnPropertyNames(zip.files);
-
-    const monodroid = entries.some((e) => e.endsWith("libmonodroid.so"));
-    const hasRuntime = entries.some((e) => e.endsWith("mscorlib.dll"));
-    const hasEnterpriseBundle = entries.some((e) => e.endsWith("libmonodroid_bundle_app.so"));
-
-    return monodroid && !hasRuntime && !hasEnterpriseBundle;
   }
 }

--- a/test/commands/test/lib/app-validator-test.ts
+++ b/test/commands/test/lib/app-validator-test.ts
@@ -34,21 +34,9 @@ describe("Validating application file", () => {
     await AppValidator.validate(appPath);
   });
 
-  it("should accept Android app without shared runtime", async () => {
+  it("should accept Android apps", async () => {
     const appPath = await createFakeAppFile("myApp.apk", []);
     await AppValidator.validate(appPath);
-  });
-
-  it("should reject Android app with shared runtime", async () => {
-    const appPath = await createFakeAppFile("myApp.apk", [ "libmonodroid.so" ]);
-    let errorCaught = false;
-    try {
-      await AppValidator.validate(appPath);
-    } catch (error) {
-      errorCaught = true;
-    }
-
-    expect(errorCaught).to.equal(true);
   });
 
   it("should reject non-Android and non-iOS applications", async () => {


### PR DESCRIPTION
Workaround JsZip bug: Removed share runtime check, check is already performed by test-cloud.exe and JsZip that was used caused problems on some apks.