### PR TITLE
Make @types packages dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -412,6 +412,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@types/unzip/-/unzip-0.1.0.tgz",
       "integrity": "sha512-fyvS5bbK6xEKDOyZSpnsqSDmazvTbC2Q61dCRcVu0xkWJxsjxwYThuCRE/l7lfJoESbfCbhGrH8ja9Yp09dBrQ==",
+      "dev": true,
       "requires": {
         "@types/node": "6.0.88"
       }
@@ -442,7 +443,8 @@
     "@types/xmldom": {
       "version": "0.1.29",
       "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.29.tgz",
-      "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E="
+      "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,10 @@
     "@types/semver": "^5.3.33",
     "@types/sinon": "^2.3.5",
     "@types/temp": "^0.8.29",
+    "@types/unzip": "^0.1.0",
     "@types/which": "^1.0.28",
     "@types/xml2js": "^0.4.0",
+    "@types/xmldom": "^0.1.29",
     "autorest": "^2.0.4238",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
@@ -85,8 +87,6 @@
     "typescript": "^2.5.2"
   },
   "dependencies": {
-    "@types/unzip": "^0.1.0",
-    "@types/xmldom": "^0.1.29",
     "azure-storage": "^2.1.0",
     "bplist": "0.0.4",
     "chalk": "^1.1.3",


### PR DESCRIPTION
Same as https://github.com/Microsoft/appcenter-cli/pull/325

If they are in `dependencies`, it enforces packages depends on `appcenter-cli` to install the same packages (@types/unzip, @types/xmldom and their dependencies).

So please add them as `devDependencies.`