### PR TITLE
Fixes JSLint error with unused os import

### DIFF
--- a/src/commands/test/download.ts
+++ b/src/commands/test/download.ts
@@ -12,7 +12,6 @@ import { buildErrorInfo } from "./lib/error-info-builder";
 import { XmlUtil } from "./lib/xml-util";
 import { XmlUtilBuilder } from "./lib/xml-util-builder";
 import * as path from "path";
-import * as os from "os";
 
 @help(Messages.TestCloud.Commands.Download)
 export default class DownloadTestsCommand extends AppCommand {


### PR DESCRIPTION
### Motivation
I didn't check my last commit. Lesson learnt, we need CI and I need to be more careful 🙂 