### PR TITLE
Fixes help description casing

### DIFF
--- a/src/commands/apps/set-current.ts
+++ b/src/commands/apps/set-current.ts
@@ -11,7 +11,7 @@ export default class SetCurrentAppCommand extends Command {
 
   @name("app")
   @position(0)
-  @help("owner/app to set as default")
+  @help("Owner/app to set as default")
   @required
   appId: string;
 


### PR DESCRIPTION
I'm parsing help description and searching for upper casing of description's first char. All descriptions start with upper cased character except for one, which is fixed in this PR.