### PR TITLE
Adds --mandatory and --disabled long arguments to codepush patch,remove

### DIFF
--- a/src/commands/codepush/patch.ts
+++ b/src/commands/codepush/patch.ts
@@ -26,10 +26,12 @@ export default class PatchCommand extends AppCommand {
 
   @help("Specifies whether this release should be considered mandatory. (Putting -m flag means mandatory)")
   @shortName("m")
+  @longName("mandatory")
   public isMandatory: boolean;
 
   @help("Specifies whether this release should be immediately downloadable. (Putting -x flag means disabled)")
   @shortName("x")
+  @longName("disabled")
   public isDisabled: boolean;
 
   @help("Specifies binary app version(s) that specifies this release is targeting for. (The value must be a semver expression such as 1.1.0, ~1.2.3)")

--- a/src/commands/codepush/promote.ts
+++ b/src/commands/codepush/promote.ts
@@ -37,10 +37,12 @@ export default class CodePushPromoteCommand extends AppCommand {
 
   @help("Specifies whether this release should be considered mandatory. (Putting -m flag means mandatory)")
   @shortName("m")
+  @longName("mandatory")
   public isMandatory: boolean;
 
   @help("Specifies whether this release should be immediately downloadable. (Putting -x flag means disabled)")
   @shortName("x")
+  @longName("disabled")
   public isDisabled: boolean;
 
   @help("Specifies that if the update is identical to the latest release on the deployment, the CLI should generate a warning instead of an error")


### PR DESCRIPTION
I've added missing long arguments versions (-x, -m) for codepush patch/remove. Every argument out there has a long version, except in this case.
I've copied the values from CodePushReleaseCommandSkeleton.