### PR TITLE
Avoid duplicate output when using --async with --output

### DIFF
--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -157,10 +157,12 @@ export abstract class RunTestsCommand extends AppCommand {
           }
         }
 
-        this.streamingOutput.text(function (testRun) {
-          const report: string = `Test Report: ${testRun.testRunUrl}` + os.EOL;
-          return report;
-        }, testRun );
+        if (!(this.async && this.format)) {
+          this.streamingOutput.text(function (testRun) {
+            const report: string = `Test Report: ${testRun.testRunUrl}` + os.EOL;
+            return report;
+          }, testRun );
+        }
 
         return success();
       }


### PR DESCRIPTION
Since `testRun` gets passed to two `this.streamingOuput.text()` calls the same data is output twice when using `--output`.