### PR TITLE
Allow debug uitest console to be used when calling appcenter-cli

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -194,7 +194,7 @@ export class UITestPreparer {
     const testCloudPathDev = path.join(toolsDir, "Xamarin.UITest.Console.exe");
 
     if (!await fileExists(testCloudPath) && !await fileExists(testCloudPathDev)) {
-      throw new Error(`Cannot find test-cloud.exe.., the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
+      throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
         `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
         `Minimum required version is "${this.getMinimumVersionString()}".`);
     }

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -191,16 +191,14 @@ export class UITestPreparer {
     }
 
     let testCloudPath = path.join(toolsDir, "test-cloud.exe");
-    const testCloudPathDev = path.join(toolsDir, "Xamarin.UITest.Console.exe");
-
-    if (!await fileExists(testCloudPath) && !await fileExists(testCloudPathDev)) {
-      throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
-        `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
-        `Minimum required version is "${this.getMinimumVersionString()}".`);
-    }
 
     if (!await fileExists(testCloudPath)) {
-      testCloudPath = testCloudPathDev;
+      testCloudPath = path.join(toolsDir, "Xamarin.UITest.Console.exe");
+      if (!await fileExists(testCloudPath)) {
+        throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
+          `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
+          `Minimum required version is "${this.getMinimumVersionString()}".`);
+      }
     }
 
     if (testCloudPath.includes(" ")) {

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -191,11 +191,16 @@ export class UITestPreparer {
     }
 
     let testCloudPath = path.join(toolsDir, "test-cloud.exe");
+    const testCloudPathDev = path.join(toolsDir, "Xamarin.UITest.Console.exe");
 
-    if (!await fileExists(testCloudPath)) {
-      throw new Error(`Cannot find test-cloud.exe, the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
+    if (!await fileExists(testCloudPath) && !await fileExists(testCloudPathDev)) {
+      throw new Error(`Cannot find test-cloud.exe.., the exe was not found in the path specified by "--uitest-tools-dir".${os.EOL}` +
         `Please check that ${testCloudPath} points to a test-cloud.exe.${os.EOL}` +
         `Minimum required version is "${this.getMinimumVersionString()}".`);
+    }
+
+    if (!await fileExists(testCloudPath)) {
+      testCloudPath = testCloudPathDev;
     }
 
     if (testCloudPath.includes(" ")) {


### PR DESCRIPTION
### Motivation
To allow the UITest CI to use the dev version of the test-cloud.exe file - we need to allow it in the CLI.

This small code change allows this (along with some changes in UITest itself).