### PR TITLE
Mark the option `--dsym-dir` as deprecated

### DIFF
--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -45,7 +45,7 @@ export module Messages {
 
       export const PrepareArtifactsDir = "Path to the artifacts directory to create";
       export const RunDevices = "Device selection slug";
-      export const RunDSymDir = "Path to the directory with iOS symbol files";
+      export const RunDSymDir = "Path to the directory with iOS symbol files. This option is deprecated and ignored";
       export const RunLocale = "The system locale for the test run. For example, en_US";
       export const RunLanguage = "Override the language (iOS only) for the test run";
       export const Fixture = "NUnit fixture / namespace to run. If used with include / exclude the fixture filter is applied first (Can be used multiple times)";

--- a/src/commands/test/lib/run-tests-command.ts
+++ b/src/commands/test/lib/run-tests-command.ts
@@ -259,8 +259,11 @@ export abstract class RunTestsCommand extends AppCommand {
     uploader.language = this.language;
     uploader.locale = this.locale;
     uploader.testSeries = this.testSeries;
-    uploader.dSymPath = this.dSymDir;
     uploader.testParameters = this.combinedParameters();
+
+    if (this.dSymDir) {
+      console.warn("The option --dsym-dir is deprecated and ignored");
+    }
 
     return await uploader.uploadAndStart();
   }

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -3,7 +3,6 @@ import { progressWithResult } from "./interaction";
 import { TestManifest, TestRunFile } from "./test-manifest";
 import { TestManifestReader } from "./test-manifest-reader";
 import { AppValidator } from "./app-validator";
-import { getDSymFile } from "./dsym-dir-helper";
 import { getOrgsNamesList } from "../../orgs/lib/org-users-helper";
 import * as PortalHelper from "../../../util/portal/portal-helper";
 import * as _ from "lodash";
@@ -32,7 +31,6 @@ export class TestCloudUploader {
   private readonly _portalBaseUrl : string;
 
   public appPath: string;
-  public dSymPath: string;
   public testParameters: { [key: string]: any };
   public testSeries: string;
   public language: string;
@@ -85,11 +83,6 @@ export class TestCloudUploader {
     const appFile = await progressWithResult("Validating application file", this.validateAndCreateAppFile(manifest));
 
     const allFiles = _.concat(manifest.testFiles, [appFile]);
-
-    if (this.dSymPath) {
-      const dSymFile = await progressWithResult("Validating DSym file", getDSymFile(this.dSymPath));
-      allFiles.push(dSymFile);
-    }
 
     await progressWithResult("Uploading files", this.uploadFilesUsingBatch(testRun.testRunId, allFiles));
 


### PR DESCRIPTION
We don't support showing symbolicated crashes.

The option `--dsym-dir` is deprecated and ignored.

The functionality with the ability to view and download raw (unsymbolicated) crash reports is available on appcenter.ms

