### PR TITLE
Parameters badly formatted when keystore used

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -143,7 +143,7 @@ export class UITestPreparer {
     command += `${testCloudBinary} prepare "${this.appPath}"`;
 
     if (this.storeFile) {
-      command += ` "${this.storeFile}" "${this.storePassword}" "${this.keyAlias}" "${this.keyPassword}"`;
+      command += ` keystore "${this.storeFile}" "${this.storePassword}" "${this.keyAlias}" "${this.keyPassword}"`;
     }
 
     command += ` --assembly-dir "${this.buildDir}" --artifacts-dir "${this.artifactsDir}"`;


### PR DESCRIPTION
Fixes incorrect parameter parsing when passing keystore details to test-cloud.exe.

Error before fix:
```
Invalid options were used to prepare the test artifacts, please try again. If you can't work out how to fix this issue, please contact support.
```