### PR TITLE
Adds a useful error message

### DIFF
--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -120,7 +120,7 @@ export class TestCloudUploader {
          (err: Error, _result: any, _request: any, response: http.IncomingMessage) => {
           if (err) {
             if ((err as any).statusCode === 404) {
-              err.message = "The app name was not found for the provided org name";
+              err.message = `The app named ${this._appName} does not exist in the organization or user: ${this._userName}`;
             }
             reject(err);
           } else {

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -119,6 +119,9 @@ export class TestCloudUploader {
          this._appName,
          (err: Error, _result: any, _request: any, response: http.IncomingMessage) => {
           if (err) {
+            if ((err as any).statusCode === 404) {
+              err.message = "The app name was not found for the provided org name";
+            }
             reject(err);
           } else {
             const location: string = response.headers["location"];


### PR DESCRIPTION
**Desciption:**
if we make a typo in an app name we get an empty error message:
```Preparing tests... done.
Validating arguments... done.
Creating new test run... failed.
Error:
```

This PR fixes that problem. We'll see the message
`The app name was not found for the provided org name`

