### PR TITLE
CodePush: Add an option to pass extra react-native bundler options

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -201,7 +201,7 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
   }
 }
 
-export function runReactNativeBundleCommand(bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string): Promise<void> {
+export function runReactNativeBundleCommand(bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string, extraBundlerOptions: string[]): Promise<void> {
   const reactNativeBundleArgs: string[] = [];
   const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
 
@@ -216,6 +216,7 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
       "--dev", development,
       "--entry-file", entryFile,
       "--platform", platform,
+      ...extraBundlerOptions,
   ]);
 
   if (sourcemapOutput) {

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -1,4 +1,4 @@
-import { CommandResult, ErrorCodes, failure, hasArg, help, longName, shortName } from "../../util/commandline";
+import { CommandResult, ErrorCodes, failure, hasArg, help, longName, shortName, defaultValue } from "../../util/commandline";
 import CodePushReleaseCommandSkeleton from "./lib/release-command-skeleton";
 import { AppCenterClient, models, clientRequest } from "../../util/apis";
 import { out } from "../../util/interaction";
@@ -65,6 +65,10 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
   @longName("target-binary-version")
   @hasArg
   public specifiedTargetBinaryVersion: string;
+
+  @help("Option that gets passed to react-native bundler. Can be specified multiple times")
+  @longName("extra-bundler-option")
+  public extraBundlerOptions: string | string[];
 
   private os: string;
 
@@ -140,10 +144,14 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
     }
 
+    if (!(this.extraBundlerOptions instanceof Array)) {
+      this.extraBundlerOptions = (typeof this.extraBundlerOptions === 'undefined') ? [] : [this.extraBundlerOptions];
+    }
+
     try {
       createEmptyTmpReleaseFolder(this.updateContentsPath);
       removeReactTmpDir();
-      await runReactNativeBundleCommand(this.bundleName, this.development, this.entryFile, this.updateContentsPath, this.os, this.sourcemapOutput);
+      await runReactNativeBundleCommand(this.bundleName, this.development, this.entryFile, this.updateContentsPath, this.os, this.sourcemapOutput, this.extraBundlerOptions);
 
       out.text(chalk.cyan("\nReleasing update contents to CodePush:\n"));
 

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -68,6 +68,8 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
 
   @help("Option that gets passed to react-native bundler. Can be specified multiple times")
   @longName("extra-bundler-option")
+  @defaultValue([])
+  @hasArg
   public extraBundlerOptions: string | string[];
 
   private os: string;
@@ -144,8 +146,8 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
     }
 
-    if (!(this.extraBundlerOptions instanceof Array)) {
-      this.extraBundlerOptions = (typeof this.extraBundlerOptions === 'undefined') ? [] : [this.extraBundlerOptions];
+    if (typeof this.extraBundlerOptions === "string") {
+      this.extraBundlerOptions = [this.extraBundlerOptions];
     }
 
     try {

--- a/src/util/commandline/option-decorators.ts
+++ b/src/util/commandline/option-decorators.ts
@@ -179,7 +179,7 @@ export function required(proto: any, propertyKey: string): void {
 
 // DefaultValue is also special, since it has to work with both as well. Same
 // basic logic
-export function defaultValue(value: string): PropertyDecorator {
+export function defaultValue(value: string | string[]): PropertyDecorator {
   return function defaultValueDecorator(proto: any, propertyKey: string): void {
     saveDecoratedValue(proto, propertyKey, "defaultValue", value, unknownDefaultValueKey);
   };

--- a/src/util/commandline/option-parser.ts
+++ b/src/util/commandline/option-parser.ts
@@ -6,13 +6,13 @@ const debug = require("debug")("appcenter-cli:util:commandline:option-parser");
 // Flag arguments
 
 export interface OptionDescription {
-  shortName?: string;    // Short flag for option, single character
-  longName?: string;     // long name for option
-  required?: boolean;    // Is this is a required parameter, if not present defaults to false
-  defaultValue?: string; // Default value for this option if it's not present
-  hasArg?: boolean;      // Does this option take an argument?
-  helpText?: string;     // Help text for this parameter
-  common?: boolean;      // Is this option an common option?
+  shortName?: string;               // Short flag for option, single character
+  longName?: string;                // long name for option
+  required?: boolean;               // Is this is a required parameter, if not present defaults to false
+  defaultValue?: string | string[]; // Default value for this option if it's not present
+  hasArg?: boolean;                 // Does this option take an argument?
+  helpText?: string;                // Help text for this parameter
+  common?: boolean;                 // Is this option an common option?
 }
 
 export interface OptionsDescription {


### PR DESCRIPTION
Added `extra-bundler-option` option to `codepush release-react`. This can be used to pass custom arguments to bundler.


My own use case: specify `--extra-bundler-option='--max-workers=1'` to limit bundler's memory use.