### PR TITLE
Custom telemetry source using '--telemetry-source' argument

### DIFF
--- a/src/util/apis/create-client.ts
+++ b/src/util/apis/create-client.ts
@@ -23,10 +23,10 @@ export interface AppCenterClientFactory {
   fromProfile(user: Profile): AppCenterClient;
 }
 
-export function createAppCenterClient(command: string[], telemetryEnabled: boolean): AppCenterClientFactory {
+export function createAppCenterClient(command: string[], telemetryEnabled: boolean, telemetrySource: string): AppCenterClientFactory {
   function createClientOptions(): any {
     debug(`Creating client options, isDebug = ${isDebug()}`);
-    const filters = [userAgentFilter, telemetryFilter(command.join(" "), telemetryEnabled)];
+    const filters = [userAgentFilter, telemetryFilter(command.join(" "), telemetryEnabled, telemetrySource)];
     return {
       filters: isDebug() ? [createLogger()].concat(filters) : filters
     };

--- a/src/util/apis/telemetry-filter.ts
+++ b/src/util/apis/telemetry-filter.ts
@@ -14,12 +14,12 @@ const sessionId : string = uuid.v4();
 const sessionHeaderName = "diagnostic-context";
 const commandNameHeaderName = "cli-command-name";
 
-export function telemetryFilter(commandName: string, telemetryIsEnabled: boolean) : {(resource: WebResource, next: any, callback: any): any} {
+export function telemetryFilter(commandName: string, telemetryIsEnabled: boolean, telemetrySource: string) : {(resource: WebResource, next: any, callback: any): any} {
   return (resource: WebResource, next: any, callback: any): any => {
     return requestPipeline.interimStream((input: Readable, output: Writable) => {
       input.pause();
       if (telemetryIsEnabled) {
-        resource.headers["internal-request-source"] = "cli";
+        resource.headers["internal-request-source"] = telemetrySource;
         resource.headers[sessionHeaderName] = sessionId;
         resource.headers[commandNameHeaderName] = commandName;
       }

--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -88,6 +88,12 @@ export class Command {
   @common
   public disableTelemetry: boolean;
 
+  @longName("telemetry-source")
+  @help("Custom telemetry source")
+  @hasArg
+  @common
+  public telemetrySource: string;
+
   // Entry point for runner. DO NOT override in command definition!
   async execute(): Promise<Result.CommandResult> {
     debug(`Initial execution of command`);
@@ -120,7 +126,9 @@ export class Command {
         return Promise.resolve(Result.failure(Result.ErrorCodes.InvalidParameter, `Unknown output format ${this.format}`));
       }
     }
-    this.clientFactory = createAppCenterClient(this.command, await telemetryIsEnabled(this.disableTelemetry));
+
+    const telemetrySource = this.telemetrySource || "cli";
+    this.clientFactory = createAppCenterClient(this.command, await telemetryIsEnabled(this.disableTelemetry), telemetrySource);
     return this.runNoClient();
   }
 

--- a/src/util/commandline/command.ts
+++ b/src/util/commandline/command.ts
@@ -1,6 +1,6 @@
 // Base class for all command handlers
 import * as Result from "./command-result";
-import { shortName, longName, help, hasArg, getOptionsDescription, getPositionalOptionsDescription, common } from "./option-decorators";
+import { shortName, longName, help, hasArg, getOptionsDescription, getPositionalOptionsDescription, common, internal } from "./option-decorators";
 import { parseOptions } from "./option-parser";
 import { setDebug, setQuiet, OutputFormatSupport, setFormatJson, out } from "../interaction";
 import { runHelp } from "./help";
@@ -89,9 +89,9 @@ export class Command {
   public disableTelemetry: boolean;
 
   @longName("telemetry-source")
-  @help("Custom telemetry source")
   @hasArg
   @common
+  @internal
   public telemetrySource: string;
 
   // Entry point for runner. DO NOT override in command definition!

--- a/src/util/commandline/help.ts
+++ b/src/util/commandline/help.ts
@@ -235,6 +235,7 @@ function sortOptionDescriptions(options: OptionDescription[]): OptionDescription
     .value();
 }
 
-function filterOptionDescriptions(options: OptionDescription[], isCommon: boolean): OptionDescription[] {
-  return isCommon ? options.filter((option) => { return option.common; }) :  options.filter((option) => { return !option.common; });
+function filterOptionDescriptions(options: OptionDescription[], isCommon: boolean, includeInternal: boolean = false): OptionDescription[] {
+  const filtered = isCommon ? options.filter((option) => { return option.common; }) : options.filter((option) => { return !option.common; });
+  return includeInternal ? filtered : filtered.filter((option) => { return !option.internal; });
 }

--- a/src/util/commandline/option-decorators.ts
+++ b/src/util/commandline/option-decorators.ts
@@ -128,6 +128,7 @@ export const longName = makeStringDecorator("longName");
 
 export const hasArg = makeBoolDecorator("hasArg");
 export const common = makeBoolDecorator("common");
+export const internal = makeBoolDecorator("internal");
 
 function makePositionalDecorator<T>(descriptionFieldName: string): PropertyDecoratorBuilder<T> {
   return function positionalDecoratorBuilder(value: T): PropertyDecorator {

--- a/src/util/commandline/option-parser.ts
+++ b/src/util/commandline/option-parser.ts
@@ -13,6 +13,7 @@ export interface OptionDescription {
   hasArg?: boolean;                 // Does this option take an argument?
   helpText?: string;                // Help text for this parameter
   common?: boolean;                 // Is this option an common option?
+  internal?: boolean;               // Is this option an internal option?
 }
 
 export interface OptionsDescription {


### PR DESCRIPTION
Allow applications to pass it's own telemetry source, when using appcenter-cli to access Visual Studio App Center