### PR TITLE
Bug: appcenter-cli: Investigate reports that test-run-prepare prepare function is being called

### DIFF
--- a/src/commands/test/lib/prepare-tests-command.ts
+++ b/src/commands/test/lib/prepare-tests-command.ts
@@ -86,7 +86,7 @@ export class PrepareTestsCommand extends Command {
   }
 
   protected prepareManifest(): Promise<string> {
-    throw new Error("This method must be overriden in derived classes");
+    throw new Error("prepareManifest method must be overriden in derived classes");
   }
 
   protected getSuccessMessage(manifestPath: string) {
@@ -94,6 +94,6 @@ export class PrepareTestsCommand extends Command {
   }
 
   protected getSourceRootDir(): string {
-    throw new Error("This method must be overriden in derived classes");
+    throw new Error("getSourceRootDir method must be overriden in derived classes");
   }
 }

--- a/src/commands/test/prepare/xcuitest.ts
+++ b/src/commands/test/prepare/xcuitest.ts
@@ -25,6 +25,10 @@ export default class PrepareXCUITestCommand extends PrepareTestsCommand {
     return preparer.prepare();
   }
 
+  protected getSourceRootDir() {
+    return this.buildDir;
+  }
+
   protected async validateOptions(): Promise<void> {
     if (this.buildDir && this.testIpaPath) {
       throw Error("--build-dir cannot be used with --test-ipa-path");


### PR DESCRIPTION
**Problem:**
Valid prepare xcuitest command
`appcenter test prepare xcuitest --artifacts-dir AppCenterTest --build-dir DerivedData/Build/Products/Debug-iphoneos --debug` triggers error from CLI: `Error: This method must be overriden in derived classes`

**Changes:**
Added missing method.