### PR TITLE
Fix release command with private key case

### DIFF
--- a/src/commands/codepush/lib/file-utils.ts
+++ b/src/commands/codepush/lib/file-utils.ts
@@ -42,7 +42,7 @@ export function moveReleaseFilesInTmpFolder(updateContentsPath: string): string 
 }
 
 export function getLastFolderInPath(path: string): string {
-  const splittedPath = path.split("/").filter((el) => { return el !== ""; });
+  const splittedPath = normalizePath(path).split("/").filter((el) => { return el !== ""; });
   if (isDirectory(path)) {
     return splittedPath[splittedPath.length - 1];
   } else {

--- a/src/commands/codepush/lib/file-utils.ts
+++ b/src/commands/codepush/lib/file-utils.ts
@@ -27,6 +27,60 @@ export function copyFileToTmpDir(filePath: string): string {
   }
 }
 
+export function moveReleaseFilesInTmpFolder(updateContentsPath: string): string {
+    let tmpUpdateContentsPath: string = temp.mkdirSync("code-push");
+    tmpUpdateContentsPath = path.join(tmpUpdateContentsPath, "CodePush");
+    fs.mkdirSync(tmpUpdateContentsPath);
+
+    if (isDirectory(updateContentsPath)) {
+      copyFolderRecursiveSync(normalizePath(updateContentsPath), normalizePath(tmpUpdateContentsPath));
+    } else {
+      copyFileSync(updateContentsPath, tmpUpdateContentsPath);
+    }
+
+    return tmpUpdateContentsPath;
+}
+
+export function getLastFolderInPath(path: string): string {
+  const splittedPath = path.split("/").filter((el) => { return el !== ""; });
+  if (isDirectory(path)) {
+    return splittedPath[splittedPath.length - 1];
+  } else {
+    return splittedPath[splittedPath.length - 2];
+  }
+}
+
+function copyFileSync(source: string, target: string) {
+  let targetFile = target;
+  if (fs.existsSync(target)) {
+      if (fs.lstatSync(target).isDirectory()) {
+          targetFile = path.join(target, path.basename(source));
+      }
+  }
+  fs.writeFileSync(targetFile, fs.readFileSync(source));
+}
+
+function copyFolderRecursiveSync(source: string, target: string) {
+  let files = [];
+
+  const targetFolder = path.join(target, path.basename(source));
+  if (!fs.existsSync(targetFolder)) {
+    fs.mkdirSync(targetFolder);
+  }
+
+  if (fs.lstatSync(source).isDirectory()) {
+    files = fs.readdirSync(source);
+    files.forEach(function (file) {
+      const curSource = path.join(source, file);
+      if (fs.lstatSync(curSource).isDirectory()) {
+        copyFolderRecursiveSync(curSource, targetFolder);
+      } else {
+        copyFileSync(curSource, targetFolder);
+      }
+    });
+  }
+}
+
 export function generateRandomFilename(length: number): string {
   let filename: string = "";
   const validChar: string = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/src/commands/codepush/lib/file-utils.ts
+++ b/src/commands/codepush/lib/file-utils.ts
@@ -40,7 +40,7 @@ export async function moveReleaseFilesInTmpFolder(updateContentsPath: string): P
       await pfs.cpFile(normalizePath(updateContentsPath), path.join(tmpUpdateContentsPath, targetFileName));
     }
 
-    return Promise.resolve(tmpUpdateContentsPath);
+    return tmpUpdateContentsPath;
 }
 
 export function getLastFolderInPath(path: string): string {

--- a/src/commands/codepush/lib/file-utils.ts
+++ b/src/commands/codepush/lib/file-utils.ts
@@ -37,7 +37,7 @@ export async function moveReleaseFilesInTmpFolder(updateContentsPath: string): P
       await pfs.cp(normalizePath(updateContentsPath), normalizePath(tmpUpdateContentsPath));
     } else {
       const targetFileName = path.parse(updateContentsPath).base;
-      await pfs.cpFile(updateContentsPath, path.join(tmpUpdateContentsPath, targetFileName));
+      await pfs.cpFile(normalizePath(updateContentsPath), path.join(tmpUpdateContentsPath, targetFileName));
     }
 
     return Promise.resolve(tmpUpdateContentsPath);

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -8,7 +8,7 @@ import * as fs from "fs";
 import * as pfs from "../../../util/misc/promisfied-fs";
 import * as chalk from "chalk";
 import { sign, zip } from "../lib/update-contents-tasks";
-import { isBinaryOrZip, normalizePath, getLastFolderInPath, moveReleaseFilesInTmpFolder, isDirectory } from "../lib/file-utils";
+import { isBinaryOrZip, getLastFolderInPath, moveReleaseFilesInTmpFolder, isDirectory } from "../lib/file-utils";
 import { environments } from "../lib/environment";
 import { isValidRange, isValidRollout, isValidDeployment } from "../lib/validation-utils";
 import { LegacyCodePushRelease }  from "../lib/release-strategy/index";

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -103,7 +103,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       // In React-Native case we should add "CodePush" name folder as root for relase files for keeping sync with React Native client SDK.
       // Also single file also should be in "CodePush" folder.
       if (platform === "react-native" && (getLastFolderInPath(this.updateContentsPath) !== "CodePush" || !isDirectory(this.updateContentsPath))) {
-        this.updateContentsPath = moveReleaseFilesInTmpFolder(normalizePath(this.updateContentsPath));
+        await moveReleaseFilesInTmpFolder(this.updateContentsPath).then((tmpPath: string) => { this.updateContentsPath = tmpPath; });
       }
 
       await sign(this.privateKeyPath, this.updateContentsPath);

--- a/test/commands/codepush/codepush-release-test.ts
+++ b/test/commands/codepush/codepush-release-test.ts
@@ -1,0 +1,65 @@
+import * as Nock from "nock";
+import * as Temp from "temp";
+import * as Sinon from "sinon";
+import { expect } from "chai";
+import release from "../../../src/commands/codepush/release";
+import * as updateContentsTasks from "../../../src/commands/codepush/lib/update-contents-tasks";
+import { getFakeParamsForRequest, createFile, getCommandArgsForReleaseCommand, FakeParamsForRequests, nockPlatformRequest, getLastFolderForSignPath, nockRequestForValidation } from "./utils";
+import { CommandArgs } from "../../../src/util/commandline";
+
+describe("CodePush release tests", () => {
+  const tmpFolderPath = Temp.mkdirSync("releaseTest");
+  const releaseFileName = "releaseBinaryFile";
+  const releaseFileContent = "Hello World!";
+
+  const fakeParamsForRequests: FakeParamsForRequests = getFakeParamsForRequest();
+
+  let nockedRequests: Nock.Scope;
+  let stubbedSign: Sinon.SinonStub;
+
+  beforeEach(() => {
+    nockedRequests = nockRequestForValidation(fakeParamsForRequests);
+    stubbedSign = Sinon.stub(updateContentsTasks, "sign");
+  });
+
+  afterEach(() => {
+    Nock.cleanAll();
+    stubbedSign.restore();
+  });
+
+  describe("CodePush signed release", () => {
+    describe("CodePush path generation", () => {
+      it("CodePush path generation for React-Native with private key", async () => {
+        // Arrange
+        const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
+        nockPlatformRequest("React-Native", fakeParamsForRequests, nockedRequests);
+        const args: CommandArgs = getCommandArgsForReleaseCommand(["-c", releaseFilePath, "-k", "fakePrivateKey.pem"], fakeParamsForRequests);
+
+        // Act
+        const testRelaseSkeleton = new release(args);
+        await testRelaseSkeleton.execute();
+
+        // Assert
+        const lastFolderForSignPath = getLastFolderForSignPath(stubbedSign);
+        expect(lastFolderForSignPath).to.eql("CodePush", "Last folder in path should be 'CodePush'");
+        nockedRequests.done();
+      });
+
+      it("CodePush path generation for Cordova with private key", async () => {
+        // Arrange
+        const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
+        nockPlatformRequest("Cordova", fakeParamsForRequests, nockedRequests);
+        const args: CommandArgs = getCommandArgsForReleaseCommand(["-c", releaseFilePath, "-k", "fakePrivateKey.pem"], fakeParamsForRequests);
+
+        // Act
+        const testRelaseSkeleton = new release(args);
+        await testRelaseSkeleton.execute();
+
+        // Assert
+        const lastFolderForSignPath = getLastFolderForSignPath(stubbedSign);
+        expect(lastFolderForSignPath).to.not.eql("CodePush", "Last folder in path shouldn't be 'CodePush'");
+        nockedRequests.done();
+      });
+    });
+  });
+});

--- a/test/commands/codepush/lib/file-utils-test.ts
+++ b/test/commands/codepush/lib/file-utils-test.ts
@@ -1,0 +1,48 @@
+import { getLastFolderInPath } from "../../../../src/commands/codepush/lib/file-utils";
+import { expect } from "chai";
+import { createTempPathWithFakeLastFolder, createFile } from "../utils";
+
+describe("file-utils test", () => {
+
+  const releaseFileName = "releaseBinaryFile";
+  const releaseFileContent = "Hello World!";
+  let testPath: string;
+  describe("`getLastFolderInPath` method", () => {
+    beforeEach(() => {
+      testPath = createTempPathWithFakeLastFolder("releaseTest", "lastFolder");
+    });
+
+    it("test for nonexistent path", () => {
+      // Arrange
+      const nonexistentPath = "nonexistent/path";
+
+      // Act
+      const throwErrorMethod = function () { getLastFolderInPath(nonexistentPath); };
+
+      // Assert
+      expect(throwErrorMethod)
+        .to.throw("ENOENT: no such file or directory");
+    });
+
+    it("test for folder", () => {
+      // Act
+      const result = getLastFolderInPath(testPath);
+
+      // Assert
+      expect(result).to.be.an("string", "Should be string");
+      expect(result).to.be.eql("lastFolder", "Should be `lastFolder`");
+    });
+
+    it("test for file", () => {
+      // Arrange
+      const testFile = createFile(testPath, releaseFileName, releaseFileContent);
+
+      // Act
+      const result = getLastFolderInPath(testFile);
+
+      // Assert
+      expect(result).to.be.an("string", "Should be string");
+      expect(result).to.be.eql("lastFolder", "Should be `lastFolder`");
+    });
+  });
+});

--- a/test/commands/codepush/utils.ts
+++ b/test/commands/codepush/utils.ts
@@ -1,0 +1,68 @@
+import * as fs from "fs";
+import * as temp from "temp";
+import * as path from "path";
+import * as Nock from "nock";
+import * as Sinon from "sinon";
+import { CommandArgs } from "../../../src/util/commandline/command";
+import { getLastFolderInPath } from "../../../src/commands/codepush/lib/file-utils";
+
+export interface FakeParamsForRequests {
+  userName: string;
+  appName: string;
+  path: string;
+  appVersion: string;
+  host: string;
+}
+
+export function getFakeParamsForRequest(): FakeParamsForRequests {
+  const fakeParamsForRequests = {
+    userName: "fakeUserName",
+    appName: "fakeAppName",
+    path: "fake/path",
+    appVersion: "v0.1",
+    host: "https://api.appcenter.ms/",
+  };
+
+  return fakeParamsForRequests;
+}
+
+export function createTempPathWithFakeLastFolder(nameTmpFolder: string, lastFolderName: string): string {
+  let testPath = temp.mkdirSync(nameTmpFolder);
+  testPath = path.join(testPath, lastFolderName);
+  fs.mkdirSync(testPath);
+  return testPath;
+}
+
+export function createFile(folderPath: string, fileName: string, fileContent: string): string {
+  const finalPath = path.join(folderPath, fileName);
+  fs.writeFileSync(finalPath, fileContent);
+  return finalPath;
+}
+
+export function getCommandArgsForReleaseCommand(additionalArgs: string[], fakeConsts: FakeParamsForRequests, ): CommandArgs {
+  const args: string[] = ["-a", `${fakeConsts.userName}/${fakeConsts.appName}`, "-d", "Staging", "-t", "1.0"].concat(additionalArgs);
+  return {
+    args,
+    command: ["codepush", "release"],
+    commandPath: fakeConsts.path,
+  };
+}
+
+export function nockRequestForValidation(fakeConsts: FakeParamsForRequests): Nock.Scope {
+  return Nock(fakeConsts.host)
+    .get(`/${fakeConsts.appVersion}/apps/${fakeConsts.userName}/${fakeConsts.appName}/deployments/Staging`)
+    .reply(200, (uri: any, requestBody: any) => { return {}; });
+}
+
+export function nockPlatformRequest(fakePlatform: string, fakeConsts: FakeParamsForRequests, nockedRequests: Nock.Scope) {
+  nockedRequests.get(`/${fakeConsts.appVersion}/apps/${fakeConsts.userName}/${fakeConsts.appName}`).reply(200, (uri: any, requestBody: any) => {
+    return { platform: fakePlatform };
+  });
+}
+
+export function getLastFolderForSignPath(stubedSign: Sinon.SinonStub): string {
+  Sinon.assert.called(stubedSign);
+
+  const signPath = stubedSign.getCalls()[0].args[1];
+  return getLastFolderInPath(signPath);
+}

--- a/test/commands/codepush/utils.ts
+++ b/test/commands/codepush/utils.ts
@@ -12,6 +12,7 @@ export interface FakeParamsForRequests {
   path: string;
   appVersion: string;
   host: string;
+  token: string;
 }
 
 export function getFakeParamsForRequest(): FakeParamsForRequests {
@@ -21,6 +22,7 @@ export function getFakeParamsForRequest(): FakeParamsForRequests {
     path: "fake/path",
     appVersion: "v0.1",
     host: "https://api.appcenter.ms/",
+    token: "c1o3d3e7",
   };
 
   return fakeParamsForRequests;
@@ -40,7 +42,7 @@ export function createFile(folderPath: string, fileName: string, fileContent: st
 }
 
 export function getCommandArgsForReleaseCommand(additionalArgs: string[], fakeConsts: FakeParamsForRequests, ): CommandArgs {
-  const args: string[] = ["-a", `${fakeConsts.userName}/${fakeConsts.appName}`, "-d", "Staging", "-t", "1.0"].concat(additionalArgs);
+  const args: string[] = ["-a", `${fakeConsts.userName}/${fakeConsts.appName}`, "-d", "Staging", "-t", "1.0", "--token", fakeConsts.token].concat(additionalArgs);
   return {
     args,
     command: ["codepush", "release"],


### PR DESCRIPTION
**Issue**: We lose private key during release for RN from custom path because there should be root folder "CodePush" for React-Native app. (For Cordova it should be "www").  

**Suggestion fix**: In private key enabled case we should check that it is React-Native app and the last folder isn't "CodePush". In this case we should copy all contents to temp folder with root "CodePush" folder and then make release from here.

