### PR TITLE
Added verification to raise an error when 'include' argument provided for Espresso and XCUITest.

### DIFF
--- a/src/commands/test/lib/appium-preparer.ts
+++ b/src/commands/test/lib/appium-preparer.ts
@@ -9,10 +9,10 @@ export class AppiumPreparer {
 
   constructor(artifactsDir: string, buildDir: string) {
     if (!artifactsDir) {
-      throw new Error("Argument artifactsDir is required");
+      throw new Error("Argument --artifacts-dir is required");
     }
     if (!buildDir) {
-      throw new Error("Argument buildDir is required");
+      throw new Error("Argument --build-dir is required");
     }
 
     this.artifactsDir = artifactsDir;

--- a/src/commands/test/lib/calabash-preparer.ts
+++ b/src/commands/test/lib/calabash-preparer.ts
@@ -19,13 +19,13 @@ export class CalabashPreparer {
 
   constructor(artifactsDir: string, projectDir: string, appPath: string, testParameters: string[]) {
     if (!artifactsDir) {
-      throw new Error("Argument artifactsDir is required");
+      throw new Error("Argument --artifacts-dir is required");
     }
     if (!projectDir) {
-      throw new Error("Argument projectDir is required");
+      throw new Error("Argument --project-dir is required");
     }
     if (!appPath) {
-      throw new Error("Argument appPath is required");
+      throw new Error("Argument --app-path is required");
     }
 
     this.artifactsDir = artifactsDir;

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -8,9 +8,13 @@ export class EspressoPreparer {
   private readonly buildDir: string;
   private readonly testApkPath: string;
 
-  constructor(artifactsDir: string, buildDir: string, testApkPath?: string) {
+  constructor(artifactsDir: string, buildDir: string, testApkPath?: string, include?: string[]) {
     if (!artifactsDir) {
-      throw new Error("Argument artifactsDir is required");
+      throw new Error("Argument --artifacts-dir is required");
+    }
+
+    if (include) {
+      throw new Error("Argument --include cannot be used for Espresso");
     }
 
     this.buildDir = buildDir;
@@ -23,7 +27,7 @@ export class EspressoPreparer {
       throw new Error("You must not specify both build dir and test apk path.");
     }
     if (!(this.buildDir || this.testApkPath)) {
-      throw new Error("Either artifacts-dir, build-dir or test-apk-path must be specified");
+      throw new Error("Either --artifacts-dir, --build-dir or --test-apk-path must be specified");
     }
   }
 

--- a/src/commands/test/lib/espresso-preparer.ts
+++ b/src/commands/test/lib/espresso-preparer.ts
@@ -13,7 +13,7 @@ export class EspressoPreparer {
       throw new Error("Argument --artifacts-dir is required");
     }
 
-    if (include) {
+    if (include && include.length) {
       throw new Error("Argument --include cannot be used for Espresso");
     }
 

--- a/src/commands/test/lib/help-messages.ts
+++ b/src/commands/test/lib/help-messages.ts
@@ -96,6 +96,8 @@ export module Messages {
       export const DownloadTestOutputDir = "Directory to download the .zip file(s) into for merging";
       export const MergedFileName = "Name of the merged XML file";
       export const Continuous = "Continuously checks the test run status until it completes";
+
+      export const NotSupported = "Attribute is not supported";
     }
   }
 }

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -30,13 +30,13 @@ export class UITestPreparer {
 
   constructor(artifactsDir: string, buildDir: string, appPath: string) {
     if (!artifactsDir) {
-      throw new Error("Argument artifactsDir is required");
+      throw new Error("Argument --artifacts-dir is required");
     }
     if (!buildDir) {
-      throw new Error("Argument buildDir is required");
+      throw new Error("Argument --build-dir is required");
     }
     if (!appPath) {
-      throw new Error("Argument appPath is required");
+      throw new Error("Argument --app-path is required");
     }
 
     this.appPath = appPath;

--- a/src/commands/test/lib/xcuitest-preparer.ts
+++ b/src/commands/test/lib/xcuitest-preparer.ts
@@ -9,17 +9,21 @@ export class XCUITestPreparer {
   private readonly buildDir: string;
   private testIpaPath: string;
 
-  constructor(artifactsDir: string, buildDir: string, testIpaPath: string) {
+  constructor(artifactsDir: string, buildDir: string, testIpaPath: string, include?: string[]) {
     if (!artifactsDir) {
-      throw new Error("Argument artifactsDir is required");
+      throw new Error("Argument --artifacts-dir is required");
     }
 
     if (!(buildDir || testIpaPath)) {
-      throw new Error("Either buildDir or testIpaPath argument is required");
+      throw new Error("Either --build-dir or --test-ipa-path argument is required");
     }
 
     if (buildDir && testIpaPath) {
-      throw new Error("Arguments buildDir and testIpaPath cannot be used together");
+      throw new Error("Arguments --build-dir and --test-ipa-path cannot be used together");
+    }
+
+    if (include) {
+      throw new Error("Argument --include cannot be used for XCUITest");
     }
 
     this.artifactsDir = artifactsDir;

--- a/src/commands/test/lib/xcuitest-preparer.ts
+++ b/src/commands/test/lib/xcuitest-preparer.ts
@@ -22,7 +22,7 @@ export class XCUITestPreparer {
       throw new Error("Arguments --build-dir and --test-ipa-path cannot be used together");
     }
 
-    if (include) {
+    if (include && include.length) {
       throw new Error("Argument --include cannot be used for XCUITest");
     }
 

--- a/src/commands/test/prepare/espresso.ts
+++ b/src/commands/test/prepare/espresso.ts
@@ -15,12 +15,17 @@ export default class PrepareEspressoCommand extends PrepareTestsCommand {
   @hasArg
   testApkPath: string;
 
+  @help(Messages.TestCloud.Arguments.NotSupported + " for Espresso")
+  @longName("include")
+  @hasArg
+  include: string[];
+
   constructor(args: CommandArgs) {
     super(args);
   }
 
   protected prepareManifest(): Promise<string> {
-    const preparer = new EspressoPreparer(this.artifactsDir, this.buildDir, this.testApkPath);
+    const preparer = new EspressoPreparer(this.artifactsDir, this.buildDir, this.testApkPath, this.include);
     return preparer.prepare();
   }
 

--- a/src/commands/test/prepare/xcuitest.ts
+++ b/src/commands/test/prepare/xcuitest.ts
@@ -16,12 +16,17 @@ export default class PrepareXCUITestCommand extends PrepareTestsCommand {
   @hasArg
   testIpaPath: string;
 
+  @help(Messages.TestCloud.Arguments.NotSupported + " for XCUITest")
+  @longName("include")
+  @hasArg
+  include: string[];
+
   constructor(args: CommandArgs) {
     super(args);
   }
 
   protected prepareManifest(): Promise<string> {
-    const preparer = new XCUITestPreparer(this.artifactsDir, this.buildDir, this.testIpaPath);
+    const preparer = new XCUITestPreparer(this.artifactsDir, this.buildDir, this.testIpaPath, this.include);
     return preparer.prepare();
   }
 

--- a/src/commands/test/run/espresso.ts
+++ b/src/commands/test/run/espresso.ts
@@ -16,6 +16,11 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
   @hasArg
   testApkPath: string;
 
+  @help(Messages.TestCloud.Arguments.NotSupported + " for Espresso")
+  @longName("include")
+  @hasArg
+  include: string[];
+
   constructor(args: CommandArgs) {
     super(args);
   }
@@ -24,7 +29,7 @@ export default class RunEspressoTestsCommand extends RunTestsCommand {
     if (!this.appPath) {
       throw new Error("Argument --app-path is required");
     }
-    const preparer = new EspressoPreparer(artifactsDir, this.buildDir, this.testApkPath);
+    const preparer = new EspressoPreparer(artifactsDir, this.buildDir, this.testApkPath, this.include);
     return preparer.prepare();
   }
 

--- a/src/commands/test/run/xcuitest.ts
+++ b/src/commands/test/run/xcuitest.ts
@@ -20,6 +20,11 @@ export default class RunXCUITestCommand extends RunTestsCommand {
   @hasArg
   testIpaPath: string;
 
+  @help(Messages.TestCloud.Arguments.NotSupported + " for XCUITest")
+  @longName("include")
+  @hasArg
+  include: string[];
+
   protected isAppPathRequired = false;
 
   constructor(args: CommandArgs) {
@@ -27,7 +32,7 @@ export default class RunXCUITestCommand extends RunTestsCommand {
   }
 
   protected prepareManifest(artifactsDir: string): Promise<string> {
-    const preparer = new XCUITestPreparer(artifactsDir, this.buildDir, this.testIpaPath);
+    const preparer = new XCUITestPreparer(artifactsDir, this.buildDir, this.testIpaPath, this.include);
     return preparer.prepare();
   }
 

--- a/test/commands/test/lib/espresso-preparer-test.ts
+++ b/test/commands/test/lib/espresso-preparer-test.ts
@@ -1,0 +1,18 @@
+import { EspressoPreparer } from "../../../../src/commands/test/lib/espresso-preparer";
+import * as chai from "chai";
+
+const expect = chai.expect;
+
+describe("Preparing Espresso workspace", () => {
+  it("should fail when 'include' argument exist", async () => {
+    const artifactsDir = "artifactsDir";
+    const buildDir = "buildDir";
+
+    try {
+      new EspressoPreparer(artifactsDir, buildDir, null, ["/includePath"]).prepare();
+    } catch (e) {
+      const ex: Error = e;
+      expect(ex.message).contain("--include");
+    }
+  });
+});

--- a/test/commands/test/lib/xcuitest-preparer-test.ts
+++ b/test/commands/test/lib/xcuitest-preparer-test.ts
@@ -1,0 +1,18 @@
+import { XCUITestPreparer } from "../../../../src/commands/test/lib/xcuitest-preparer";
+import * as chai from "chai";
+
+const expect = chai.expect;
+
+describe("Preparing XCUITest workspace", () => {
+  it("should fail when 'include' argument exist", async () => {
+    const artifactsDir = "artifactsDir";
+    const buildDir = "buildDir";
+
+    try {
+      new XCUITestPreparer(artifactsDir, buildDir, null, ["/includePath"]).prepare();
+    } catch (e) {
+      const ex: Error = e;
+      expect(ex.message).contain("--include");
+    }
+  });
+});


### PR DESCRIPTION
**Problem:** `--include` argument is not supported for `Espresso` and `XCUITest`.

**Changes:**
- Added verification to raise an error when 'include' argument provided for Espresso and XCUITest.
- Unified error messages.
- Changed help messages for 'include' argument for Espresso and XCUITest.
- Added tests.

---
Error messages for Espresso/XCUITest:
```
Error: Argument --include cannot be used for Espresso
Error: Argument --include cannot be used for XCUITest
```

Help messages for Espresso/XCUITest/other:
```
--include <arg>           Attribute is not supported for Espresso
--include <arg>           Attribute is not supported for XCUITest
--include <arg>           Additional files and directories to include. The value must be either path relative to the input directory, or be in format "targetDir=sourceDir"
```