### PR TITLE
Release 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter telemetry off` | Turn off the sending of telemetry |
 | `appcenter telemetry on` | Turn on the sending of telemetry |
 | | |
-| `appcenter test download` | Download the report artifacts, unpack and merge them |
+| `appcenter test download` | Download the report artifacts, unpack and merge them. This command is only available for UITest and Appium test runs |
 | `appcenter test status` | Checks the status of the started test run |
 | `appcenter test stop` | Stop the started test run |
 | `appcenter test wizard` | Start a test run interactively. All the parameters will be prompted on-the-go |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
- Adds verification error for `appcenter test run` on appium and xcuitest when --include parameter is used
- Updates launch tests to always use latest UITest version
- Fixes access token error on codepush command - [Issue 469](https://github.com/Microsoft/appcenter-cli/issues/469)
- Updates package npm dependencies