### PR TITLE
Fixed logic of detecting existing distribution groups.

### DIFF
--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -110,10 +110,15 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
     if (!_.isNil(name)) {
       try {
         const httpRequest = await clientRequest<models.DistributionGroupResponse>((cb) => client.distributionGroups.get(app.ownerName, app.appName, name, cb));
-        if (httpRequest.response.statusCode !== 404) {
-          throw httpRequest.response.statusCode;
-        }
+
+        // Throw an exception if 404 error was not thrown during clientRequest
+        throw httpRequest.response.statusCode;
       } catch (error) {
+        if (error && error.response && error.response.statusCode === 404) {
+          // 404 is correct status code for this case
+          return;
+        }
+
         if (error === 200) {
           throw failure(ErrorCodes.InvalidParameter, `distribution group ${name} already exists`);
         } else {

--- a/test/commands/distribute/groups/download-test.ts
+++ b/test/commands/distribute/groups/download-test.ts
@@ -5,8 +5,8 @@ import * as Path from "path";
 import * as Temp from "temp";
 import * as _ from "lodash";
 
-import DownloadBinaryFromDistributionGroupCommand from "../../../../../src/commands/distribute/groups/download";
-import { CommandArgs, CommandResult } from "../../../../../src/util/commandline";
+import DownloadBinaryFromDistributionGroupCommand from "../../../../src/commands/distribute/groups/download";
+import { CommandArgs, CommandResult } from "../../../../src/util/commandline";
 
 Temp.track();
 

--- a/test/commands/distribute/groups/update-test.ts
+++ b/test/commands/distribute/groups/update-test.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+import * as Nock from "nock";
+import * as _ from "lodash";
+
+import UpdateDistributionGroupCommand from "../../../../src/commands/distribute/groups/update";
+import { CommandArgs, CommandResult } from "../../../../src/util/commandline";
+
+describe("distribute groups update command", () => {
+  const fakeAppOwner = "fakeAppOwner";
+  const fakeAppName = "fakeAppName";
+  const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;
+  const fakeToken = "c1o3d3e7";
+  const fakeDistributionGroupName = "fakeDistributionGroupName";
+  const updatedFakeDistributionGroupName = "updatedFakeDistributionGroupName";
+  /* tslint:disable-next-line:no-http-string */
+  const fakeHost = "http://localhost:1700";
+
+  before(() => {
+    Nock.disableNetConnect();
+  });
+
+  it("throws an exception when distribution group exists in AppCenter", async () => {
+    // Arrange
+    let errorMessage: string;
+    const executionScope = setupDistributionGroupFoundResponse(Nock(fakeHost));
+    const skippedScope = _.flow(setupDistributionGroupNotFoundResponse, setupDistributionGroupUpdateResponse)(Nock(fakeHost));
+    const expectedErrorMessage = `distribution group ${updatedFakeDistributionGroupName} already exists`;
+
+    // Act
+    const command = new UpdateDistributionGroupCommand(getCommandArgs(["-g", fakeDistributionGroupName, "-n", updatedFakeDistributionGroupName]));
+
+    try {
+      await command.execute();
+    } catch (e) {
+      errorMessage = e.errorMessage;
+    }
+
+    // Assert
+    expect(errorMessage).to.eql(expectedErrorMessage, `Command should throw "${expectedErrorMessage}" exception`);
+    testCommandFailure(executionScope, skippedScope);
+  });
+
+  it("updates distribution group when distribution group does not exists in AppCenter", async () => {
+    // Arrange
+    const executionScope = _.flow(setupDistributionGroupNotFoundResponse, setupDistributionGroupUpdateResponse)(Nock(fakeHost));
+    const skippedScope = setupDistributionGroupFoundResponse(Nock(fakeHost));
+
+    // Act
+    const command = new UpdateDistributionGroupCommand(getCommandArgs(["-g", fakeDistributionGroupName, "-n", updatedFakeDistributionGroupName]));
+    const result = await command.execute();
+
+    // Assert
+    testCommandSuccess(result, executionScope, skippedScope);
+  });
+
+  afterEach(() => {
+    Nock.cleanAll();
+  });
+
+  after(() => {
+    Nock.enableNetConnect();
+  });
+
+  function testCommandSuccess(result: CommandResult, executionScope: Nock.Scope, abortScope?: Nock.Scope) {
+    console.log(result);
+    expect(result.succeeded).to.eql(true, "Command should be successfully completed");
+    expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    executionScope.done(); // All normal API calls are executed
+  }
+
+  function testCommandFailure(executionScope: Nock.Scope, abortScope?: Nock.Scope) {
+    expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    executionScope.done(); // All normal API calls are executed
+  }
+
+  function getCommandArgs(additionalArgs: string[]): CommandArgs {
+    const args: string[] = ["-a", fakeAppIdentifier, "--token", fakeToken, "--env", "local"].concat(additionalArgs);
+    return {
+      args,
+      command: ["distribute", "groups", "update"],
+      commandPath: "FAKE_COMMAND_PATH"
+    };
+  }
+
+  function setupDistributionGroupFoundResponse(nockScope: Nock.Scope) {
+    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${updatedFakeDistributionGroupName}`)
+      .reply(200, {
+        id: "7dbdfd81-342b-4a38-a4dd-d05379abe19d",
+        name: updatedFakeDistributionGroupName,
+        origin: "appcenter",
+        display_name: updatedFakeDistributionGroupName,
+        is_public: false
+      });
+  }
+
+  function setupDistributionGroupNotFoundResponse(nockScope: Nock.Scope) {
+    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${updatedFakeDistributionGroupName}`)
+      .reply(404, {
+        error: {
+          code: "NotFound",
+          message: `Could not find distribution group with name ${updatedFakeDistributionGroupName}`
+        }
+      });
+  }
+
+  function setupDistributionGroupUpdateResponse(nockScope: Nock.Scope) {
+    return nockScope.patch(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}`)
+      .reply(200, {
+        id: "7dbdfd81-342b-4a38-a4dd-d05379abe19d",
+        name: updatedFakeDistributionGroupName,
+        origin: "appcenter",
+        display_name: updatedFakeDistributionGroupName,
+        is_public: false
+      });
+  }
+});


### PR DESCRIPTION
**Problem:**
AppCenter CLI have a problem with changing distribution group name:
`appcenter distribute groups update --group "Test" --app "v-anmits-mrwf/TestApp" --name "TestUpdated" --debug`
returns an error:
```
\ Validating parameters...Response status code: 404

Body: {"error":{"code":"NotFound","message":"Could not find distribution group with name TestUpdated"}}

Error: failed to check if the distribution group TestUpdated already exists
```

**Changes:**
- Fixed logic of detecting existing distribution groups.
- Added tests.
- Moved download test to correct folder.

![image](https://user-images.githubusercontent.com/7479096/44531622-e858c780-a6f9-11e8-9320-c0d06e1ad9f0.png)

