### PR TITLE
App Center CLI tab completion generates a `command not found` error

### DIFF
--- a/src/util/commandline/autocomplete.ts
+++ b/src/util/commandline/autocomplete.ts
@@ -41,22 +41,36 @@ export function setupAutoCompleteForShell(path?: string, shell?: string): any {
     initFile = autoCompleteObject.getDefaultShellInitFile();
   }
 
-  // For bash we need to enable bash_completion before appcenter cli completion
-  if (autoCompleteObject.shell === "bash") {
-    const sources = `[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+  let initFileContent;
+
+  try {
+    initFileContent = Fs.readFileSync(initFile, { encoding: "utf-8" });
+  } catch (exception) {
+    throw `Can't read init file (${initFile}): ${exception}`;
+  }
+
+  try {
+    // For bash we need to enable bash_completion before appcenter cli completion
+    if (autoCompleteObject.shell === "bash" && initFileContent.indexOf("begin bash_completion configuration") === -1) {
+      const sources = `[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
 [ -f /usr/share/bash-completion/bash_completion ] && . /usr/share/bash-completion/bash_completion
 [ -f /etc/bash_completion ] && . /etc/bash_completion`;
 
-    const template = `
+      const template = `
 # begin bash_completion configuration for ${appName} completion
 ${sources}
 # end bash_completion configuration for ${appName} completion
 `;
 
-    Fs.appendFileSync(initFile, template);
-  }
+      Fs.appendFileSync(initFile, template);
+    }
 
-  autoCompleteObject.setupShellInitFile(initFile);
+    if (initFileContent.indexOf(`begin ${appName} completion`) === -1) {
+      autoCompleteObject.setupShellInitFile(initFile);
+    }
+  } catch (exception) {
+    throw `Can't setup autocomplete. Please make sure that init file (${initFile}) exist and you have write permissions: ${exception}`;
+  }
 }
 
 function getReplyHandler(lineEndsWithWhitespaceChar: boolean): (args: string[], autocompleteTree: IAutocompleteTree) => string[] {

--- a/test/util/commandline/autocomplete-test.ts
+++ b/test/util/commandline/autocomplete-test.ts
@@ -37,6 +37,21 @@ describe("autocomplete", () => {
     expect(testProfileContent).contain("begin appcenter completion");
   });
 
+  it("should not enable bash_completion and appcenter completion if autocomplete was enabled before", () => {
+    // Arange
+    fs.appendFileSync(testProfilePath, "begin appcenter completion");
+
+    // Act
+    autocomplete.setupAutoCompleteForShell(testProfilePath, "zsh");
+
+    // Assert
+    const testProfileContent = fs.readFileSync(testProfilePath, { encoding: "utf-8" });
+
+    expect(testProfileContent).contain("Test bash_profile data");
+    expect(testProfileContent).not.contain("end bash_completion");
+    expect(testProfileContent).not.contain("end appcenter completion");
+  });
+
   afterEach(() => {
     sandbox.restore();
     fs.writeFileSync(testProfilePath, "Test bash_profile data");

--- a/test/util/commandline/autocomplete-test.ts
+++ b/test/util/commandline/autocomplete-test.ts
@@ -1,0 +1,44 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as Sinon from "sinon";
+import * as autocomplete from "../../../src/util/commandline/autocomplete";
+import { expect } from "chai";
+
+describe("autocomplete", () => {
+  let sandbox: Sinon.SinonSandbox = null;
+  const testProfilePath: string = path.join(__dirname, "test-data/test-bash-profile");
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+    sandbox.stub(process, "exit");
+  });
+
+  it("should enable bash_completion and appcenter completion in init file for bash", () => {
+    // Act
+    autocomplete.setupAutoCompleteForShell(testProfilePath, "bash");
+
+    // Assert
+    const testProfileContent = fs.readFileSync(testProfilePath, { encoding: "utf-8" });
+
+    expect(testProfileContent).contain("Test bash_profile data");
+    expect(testProfileContent).contain("begin bash_completion");
+    expect(testProfileContent).contain("begin appcenter completion");
+  });
+
+  it("should not enable bash_completion, but should enable appcenter completion in init file for zsh", () => {
+    // Act
+    autocomplete.setupAutoCompleteForShell(testProfilePath, "zsh");
+
+    // Assert
+    const testProfileContent = fs.readFileSync(testProfilePath, { encoding: "utf-8" });
+
+    expect(testProfileContent).contain("Test bash_profile data");
+    expect(testProfileContent).not.contain("begin bash_completion");
+    expect(testProfileContent).contain("begin appcenter completion");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    fs.writeFileSync(testProfilePath, "Test bash_profile data");
+  });
+});

--- a/test/util/commandline/test-data/test-bash-profile
+++ b/test/util/commandline/test-data/test-bash-profile
@@ -1,0 +1,1 @@
+Test bash_profile data


### PR DESCRIPTION
**Problem:** App Center CLI tab completion generates a `command not found` error on MacOS and some Linux environments in `Bash`. In `zsh` and `fish` everything looks good.

**Issues:** https://github.com/Microsoft/appcenter-cli/issues/285 https://github.com/Microsoft/appcenter-cli/issues/340

**Root-cause:**
App Center CLI tab completion depends on `bash_completion` which should be enabled in `bash_profile` before `appcenter completion`.

**Changes:**
- Implemented logic to enable bash_completion in bash_profile before appcenter completion. 
- Implemented test to verify autocomplete initialization.
