### PR TITLE
Updated tasks.json to version 2.0.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,18 +1,20 @@
 {
   // See https://go.microsoft.com/fwlink/?LinkId=733558
   // for the documentation about the tasks.json format
-  "version": "0.1.0",
+  "version": "2.0.0",
   "command": "gulp",
-  "isShellCommand": true,
   "args": [
     "--no-color"
   ],
   "tasks": [
     {
-      "taskName": "build-sourcemaps",
+      "label": "build-sourcemaps",
       "args": [ "build-sourcemaps" ],
-      "isBuildCommand": true,
-      "isWatching": false,
+      "type": "shell",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
       "problemMatcher": [
         "$lessCompile",
         "$tsc",


### PR DESCRIPTION
**Problem**: when I try to start debugging in VSCode with task `Launch with sourcemaps`(defined in `.vscode/launch.json`) I get error dialog with message `The preLaunchTask 'build-sourcemaps' terminated with exit code 1.` and the following output:
```
[17:50:46] Using gulpfile ~/Projects/appcenter-cli/gulpfile.js
[17:50:46] Starting 'build-sourcemaps'...
[17:50:46] Starting 'build-sourcemaps'...
[17:50:46] Starting 'build-ts-sourcemaps'...
[17:50:46] Starting 'copy-assets'...
[17:50:46] Starting 'copy-generated-client'...
[17:50:46] Starting 'build-ts-sourcemaps'...
[17:50:46] Starting 'copy-assets'...
[17:50:46] Starting 'copy-generated-client'...
[17:50:46] 'build-ts-sourcemaps' errored after 31 ms
[17:50:46] Error: gulp-typescript: A project cannot be used in two compilations at the same time. Create multiple projects with createProject instead.
    at project (~/Projects/appcenter-cli/node_modules/gulp-typescript/release/project.js:43:19)
    at ~/Projects/appcenter-cli/gulpfile.js:31:11
    at taskWrapper (~/Projects/appcenter-cli/node_modules/undertaker/lib/set-task.js:13:15)
    at bound (domain.js:301:14)
    at runBound (domain.js:314:12)
    at asyncRunner (~/Projects/appcenter-cli/node_modules/async-done/index.js:55:18)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
[17:50:46] 'build-sourcemaps' errored after 34 ms
[17:50:46] The following tasks did not complete: build-sourcemaps, <parallel>, build-ts-sourcemaps, copy-assets, copy-generated-client, copy-assets, copy-generated-client
[17:50:46] Did you forget to signal async completion?
```

**Solution**: update tasks.json to version 2.0.0