### PR TITLE
Release 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
- Fixed logic of detecting existing distribution groups
- Improved error handling for generate uitest command
- Xamarin.UITest Android sign-info option fixed
- App Center CLI tab completion no longer generates a `command not found`