### PR TITLE
Fix generating sourceMaps for react-native CodePush

### DIFF
--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -128,10 +128,6 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
       }
     }
 
-    if (this.outputDir) {
-      this.sourcemapOutput = path.join(this.updateContentsPath, this.bundleName + ".map");
-    }
-
     this.targetBinaryVersion = this.specifiedTargetBinaryVersion;
 
     if (this.targetBinaryVersion && !isValidRange(this.targetBinaryVersion)) {


### PR DESCRIPTION
**Issue:** In case if user uses `--outputDir` option(custom directory for generating bundle) SourceMap will be generated in this `outputDir` directory even if user provide custom path for sourceMaps with `--sourcemap-output` option.
Note: SourceMaps is not generated in default case(without `--outputDir` and `--sourcemap-output` options)

**Solution:** SourceMap should be generated only if user provide some path for this in  `--sourcemap-output` option. 
Removed `if` block for forced generating sourceMaps.

Related issue: https://github.com/Microsoft/appcenter-cli/issues/504