### PR TITLE
Add AAR as supported package extension

### DIFF
--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -15,7 +15,7 @@ const debug = require("debug")("appcenter-cli:commands:build:download");
 
 @help("Download the binary, logs or symbols for a completed build")
 export default class DownloadBuildStatusCommand extends AppCommand {
-  private static readonly applicationPackagesExtensions: string[] = [".apk", ".ipa", ".xcarchive"];
+  private static readonly applicationPackagesExtensions: string[] = [".apk", ".aar", ".ipa", ".xcarchive"];
 
   private static readonly buildType = "build";
   private static readonly logsType = "logs";


### PR DESCRIPTION
This PR adds support for `AAR` packages for Android when downloading a build.