### PR TITLE
Add option to specify the file name when downloading a build

### DIFF
--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -45,6 +45,12 @@ export default class DownloadBuildStatusCommand extends AppCommand {
   @hasArg
   public directory: string;
 
+  @help("Download destination file")
+  @shortName("f")
+  @longName("file")
+  @hasArg
+  public file: string;
+
   public async run(client: AppCenterClient): Promise<CommandResult> {
     this.type = this.getNormalizedTypeValue(this.type);
 
@@ -106,6 +112,10 @@ export default class DownloadBuildStatusCommand extends AppCommand {
   }
 
   private async generateNameForOutputFile(branchName: string, extension: string): Promise<string> {
+    if (this.file) {
+      return this.file.includes(extension) ? this.file : `${this.file}.${extension}`;
+    }
+
     // file name should be unique for the directory
     const filesInDirectory = (await Pfs.readdir(this.directory)).map((name) => name.toLowerCase());
     let id = 1;


### PR DESCRIPTION
This PR adds a way of specifying the file name (by `--file` or `-f` option) for the `download` build command.

My use-case is that I need to download the build on a CI and I want to download it with the same file name every time.