### PR TITLE
Improve help text for build download command

### DIFF
--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -39,13 +39,13 @@ export default class DownloadBuildStatusCommand extends AppCommand {
   @hasArg
   public type: string;
 
-  @help("Download destination path")
+  @help("Destination path. Optional parameter to override the default destination path of the downloaded build")
   @shortName("d")
   @longName("dest")
   @hasArg
   public directory: string;
 
-  @help("Download destination file")
+  @help("Destination file. Optional parameter to override the default auto-generated file name")
   @shortName("f")
   @longName("file")
   @hasArg


### PR DESCRIPTION
As per https://github.com/Microsoft/appcenter-cli/pull/522#issuecomment-454747704, here's a small improvement on the help text for build download command.

Will look like this:

![image](https://user-images.githubusercontent.com/6207220/51248158-9574fa80-198f-11e9-8398-936b32eca7c5.png)

cc @owenniblock :)