### PR TITLE
Support breakpad symbol uploading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2515,7 +2515,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2536,12 +2537,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2556,17 +2559,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2683,7 +2689,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2695,6 +2702,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2709,6 +2717,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2716,12 +2725,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2740,6 +2751,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2820,7 +2832,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2832,6 +2845,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2917,7 +2931,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2953,6 +2968,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2972,6 +2988,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3015,12 +3032,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.12",
+  "version": "1.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.12",
+  "version": "1.1.11",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",

--- a/src/commands/crashes/lib/symbols-uploading-helper.ts
+++ b/src/commands/crashes/lib/symbols-uploading-helper.ts
@@ -4,12 +4,18 @@ import { DefaultApp } from "../../../util/profile";
 import { inspect } from "util";
 import AzureBlobUploadHelper from "./azure-blob-upload-helper";
 
+// eventually we may want to support AndroidProGuard or UWP here
+export enum SymbolType {
+  Apple = "Apple",
+  Breakpad = "Breakpad"
+}
+
 export default class SymbolsUploadingHelper {
   constructor(private client: AppCenterClient, private app: DefaultApp, private debug: Function) {}
 
-  public async uploadSymbolsZip(zip: string): Promise<void> {
+  public async uploadSymbolsZip(zip: string, symbolType: SymbolType): Promise<void> {
     // executing API request to get an upload URL
-    const uploadingBeginRequestResult = await this.executeSymbolsUploadingBeginRequest(this.client, this.app);
+    const uploadingBeginRequestResult = await this.executeSymbolsUploadingBeginRequest(this.client, this.app, symbolType);
 
     // uploading
     const symbolUploadId = uploadingBeginRequestResult.symbolUploadId;
@@ -28,10 +34,10 @@ export default class SymbolsUploadingHelper {
     }
   }
 
-  private async executeSymbolsUploadingBeginRequest(client: AppCenterClient, app: DefaultApp): Promise<models.SymbolUploadBeginResponse> {
+  private async executeSymbolsUploadingBeginRequest(client: AppCenterClient, app: DefaultApp, symbolType: SymbolType): Promise<models.SymbolUploadBeginResponse> {
     this.debug("Executing API request to get uploading URL");
     const uploadingBeginResponse = await clientRequest<models.SymbolUploadBeginResponse>((cb) => client.symbolUploads.create(
-      { symbolType: "Apple" }, // Temporary hard coding until type is threaded through the commands
+      { symbolType },
       app.ownerName,
       app.appName,
       cb)).catch((error: any) => {

--- a/src/commands/crashes/upload-missing-symbols.ts
+++ b/src/commands/crashes/upload-missing-symbols.ts
@@ -5,7 +5,7 @@ import { help, name, position } from "../../util/commandline";
 import { inspect } from "util";
 import { out } from "../../util/interaction";
 import { DefaultApp } from "../../util/profile";
-import UploadSymbolsHelper from "./lib/symbols-uploading-helper";
+import UploadSymbolsHelper, { SymbolType } from "./lib/symbols-uploading-helper";
 import { getSymbolsZipFromXcarchive } from "./lib/subfolder-symbols-helper";
 import { createTempFileFromZip } from "./lib/temp-zip-file-helper";
 import { mdfind } from "./lib/mdfind";
@@ -264,6 +264,6 @@ export default class UploadMissingSymbols extends AppCommand {
 
     const tempFilePath = await createTempFileFromZip(zip);
 
-    await helper.uploadSymbolsZip(tempFilePath);
+    await helper.uploadSymbolsZip(tempFilePath, SymbolType.Apple);
   }
 }

--- a/src/commands/crashes/upload-symbols.ts
+++ b/src/commands/crashes/upload-symbols.ts
@@ -48,7 +48,7 @@ export default class UploadSymbols extends AppCommand {
   @hasArg
   public sourceMapPath: string;
 
-  @help("Path to a breakpad symbols zip collection.")
+  @help("Path to a zip file containing Breakpad symbols.")
   @shortName("b")
   @longName("breakpad")
   @hasArg
@@ -81,7 +81,7 @@ export default class UploadSymbols extends AppCommand {
     }
 
     let pathToZipToUpload: string;
-    if (typeof (zip) === "string") {
+    if (typeof(zip) === "string") {
       // path to zip can be passed as it is
       pathToZipToUpload = zip;
     } else {
@@ -179,8 +179,6 @@ export default class UploadSymbols extends AppCommand {
       throw failure(ErrorCodes.InvalidParameter, "'--symbol' and '--breakpad' switches are mutually exclusive");
     } else if (!_.isNil(this.xcarchivePath) && !_.isNil(this.breakpadPath)) {
       throw failure(ErrorCodes.InvalidParameter, "'--xcarchive' and '--breakpad' switches are mutually exclusive");
-    } else if (!_.isNil(this.breakpadPath) && !_.isNil(this.sourceMapPath)) {
-      throw failure(ErrorCodes.InvalidParameter, "'--breakpad' and '--sourcemap' switches are mutually exclusive");
     }
   }
 
@@ -201,7 +199,7 @@ export default class UploadSymbols extends AppCommand {
     }
 
     let zipToChange: JsZip;
-    if (typeof (zip) === "string") {
+    if (typeof(zip) === "string") {
       // loading ZIP to add file to it
       debug("Loading ZIP into the memory to add files");
       try {

--- a/src/commands/crashes/upload-symbols.ts
+++ b/src/commands/crashes/upload-symbols.ts
@@ -8,6 +8,7 @@ import { DefaultApp } from "../../util/profile";
 import UploadSymbolsHelper from "./lib/symbols-uploading-helper";
 import { getSymbolsZipFromXcarchive, packDsymParentFolderContents, getChildrenDsymFolderPaths } from "./lib/subfolder-symbols-helper";
 import { createTempFileFromZip } from "./lib/temp-zip-file-helper";
+import { SymbolType } from "./lib/symbols-uploading-helper";
 
 import * as Fs from "fs";
 import * as Pfs from "../../util/misc/promisfied-fs";
@@ -47,18 +48,30 @@ export default class UploadSymbols extends AppCommand {
   @hasArg
   public sourceMapPath: string;
 
+  @help("Path to a breakpad symbols zip collection.")
+  @shortName("b")
+  @longName("breakpad")
+  @hasArg
+  public breakpadPath: string;
+
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const app: DefaultApp = this.app;
 
     this.validateParameters();
 
     let zip: JsZip | string; // it is either JsZip object or path to ZIP file
+    let symbolType: SymbolType;
     if (!_.isNil(this.symbolsPath)) {
       // processing -s switch value
       zip = await out.progress("Preparing ZIP with symbols...", this.prepareZipFromSymbols(this.symbolsPath));
+      symbolType = SymbolType.Apple;
+    } else if (!_.isNil(this.breakpadPath)) {
+      zip = await out.progress("Preparing ZIP with Breakpad symbols...", this.prepareZipFromSymbols(this.breakpadPath));
+      symbolType = SymbolType.Breakpad;
     } else {
       // process -x switch value
       zip = await out.progress("Preparing ZIP with symbols from xcarchive...", this.prepareZipFromXcArchive(this.xcarchivePath));
+      symbolType = SymbolType.Apple;
     }
 
     // process -m switch if specified
@@ -68,7 +81,7 @@ export default class UploadSymbols extends AppCommand {
     }
 
     let pathToZipToUpload: string;
-    if (typeof(zip) === "string") {
+    if (typeof (zip) === "string") {
       // path to zip can be passed as it is
       pathToZipToUpload = zip;
     } else {
@@ -77,7 +90,7 @@ export default class UploadSymbols extends AppCommand {
     }
 
     // upload symbols
-    await out.progress("Uploading symbols...", new UploadSymbolsHelper(client, app, debug).uploadSymbolsZip(pathToZipToUpload));
+    await out.progress("Uploading symbols...", new UploadSymbolsHelper(client, app, debug).uploadSymbolsZip(pathToZipToUpload, symbolType));
 
     return success();
   }
@@ -158,10 +171,16 @@ export default class UploadSymbols extends AppCommand {
 
   private validateParameters() {
     // check that user have selected either --symbol or --xcarchive
-    if (_.isNil(this.symbolsPath) && _.isNil(this.xcarchivePath)) {
-      throw failure(ErrorCodes.InvalidParameter, "specify either '--symbol' or '--xcarchive' switch");
+    if (_.isNil(this.symbolsPath) && _.isNil(this.xcarchivePath) && _.isNil(this.breakpadPath)) {
+      throw failure(ErrorCodes.InvalidParameter, "specify either '--symbol', '--xcarchive', or '--breakpad' switch");
     } else if (!_.isNil(this.symbolsPath) && !_.isNil(this.xcarchivePath)) {
       throw failure(ErrorCodes.InvalidParameter, "'--symbol' and '--xcarchive' switches are mutually exclusive");
+    } else if (!_.isNil(this.symbolsPath) && !_.isNil(this.breakpadPath)) {
+      throw failure(ErrorCodes.InvalidParameter, "'--symbol' and '--breakpad' switches are mutually exclusive");
+    } else if (!_.isNil(this.xcarchivePath) && !_.isNil(this.breakpadPath)) {
+      throw failure(ErrorCodes.InvalidParameter, "'--xcarchive' and '--breakpad' switches are mutually exclusive");
+    } else if (!_.isNil(this.breakpadPath) && !_.isNil(this.sourceMapPath)) {
+      throw failure(ErrorCodes.InvalidParameter, "'--breakpad' and '--sourcemap' switches are mutually exclusive");
     }
   }
 
@@ -182,7 +201,7 @@ export default class UploadSymbols extends AppCommand {
     }
 
     let zipToChange: JsZip;
-    if (typeof(zip) === "string") {
+    if (typeof (zip) === "string") {
       // loading ZIP to add file to it
       debug("Loading ZIP into the memory to add files");
       try {

--- a/src/commands/crashes/upload-symbols.ts
+++ b/src/commands/crashes/upload-symbols.ts
@@ -179,6 +179,8 @@ export default class UploadSymbols extends AppCommand {
       throw failure(ErrorCodes.InvalidParameter, "'--symbol' and '--breakpad' switches are mutually exclusive");
     } else if (!_.isNil(this.xcarchivePath) && !_.isNil(this.breakpadPath)) {
       throw failure(ErrorCodes.InvalidParameter, "'--xcarchive' and '--breakpad' switches are mutually exclusive");
+    } else if (!_.isNil(this.breakpadPath) && !_.isNil(this.sourceMapPath)) {
+      throw failure(ErrorCodes.InvalidParameter, "'--breakpad' and '--sourcemap' switches are mutually exclusive");
     }
   }
 

--- a/test/commands/crashes/upload-symbols/upload-symbols-test.ts
+++ b/test/commands/crashes/upload-symbols/upload-symbols-test.ts
@@ -69,7 +69,7 @@ describe("upload-symbols command", () => {
     abortSymbolUploadSpy = Sinon.spy();
   });
 
-  describe("when Breakpad network requests are successfu", () => {
+  describe("when Breakpad network requests are successful", () => {
     beforeEach(() => {
       expectedRequestsScope = _.flow(setupSuccessfulBreakpadPatchUploadResponse, setupSuccessfulBreakpadPostUploadResponse)(Nock(fakeHost));
       skippedRequestsScope = setupSuccessfulBreakpadAbortUploadResponse(Nock(fakeHost));


### PR DESCRIPTION
This change adds support for uploading Breakpad symbols via the `crashes upload-symbols` command. Previously, all types of symbols were uploaded with the symbol_type attribute set to "Apple". 

Now, Breakpad symbols are able to be passed in using the `-b` flag.