### PR TITLE
Release 1.1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter codepush patch` | Update the metadata for an existing CodePush release |
 | `appcenter codepush promote` | Create a new release for the destination deployment, which includes the exact code and metadata from the latest release of the source deployment |
 | `appcenter codepush release-cordova` | Release a Cordova update to an app deployment |
+| `appcenter codepush release-electron` | Release a Electron update to an deployment |
 | `appcenter codepush release-react` | Release a React Native update to an app deployment |
-| `appcenter codepush release-electron` | Release an Electron update to an app deployment |
 | `appcenter codepush release` | Release an update to an app deployment |
 | `appcenter codepush rollback` | Rollback a deployment to a previous release |
 | `appcenter codepush deployment add` | Add a new deployment to an app |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
- Updates launch test for App Center Build Appium upgrade
- Adds sourcemap-output-dir [for this issue](https://github.com/Microsoft/appcenter-cli/issues/538)
- Checks that `--app` arg is set in test wizard functionality
- Adds support for `release-electron` to code-push
- Adds support for beakpad symbol uploads