### PR TITLE
Add `distribute releases edit` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter distribute releases delete` | Deletes the release |
 | `appcenter distribute releases list` | Shows the list of all releases for the application |
 | `appcenter distribute releases show` | Shows full details about release |
+| `appcenter distribute releases edit` | Enables/disables the release |
 | | |
 | `appcenter orgs create` | Create a new organization |
 | `appcenter orgs list` | Lists organizations in which current user is collaborator |

--- a/src/commands/distribute/releases/edit.ts
+++ b/src/commands/distribute/releases/edit.ts
@@ -1,0 +1,71 @@
+import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg, position, name } from "../../../util/commandline";
+import { AppCenterClient, clientRequest, models } from "../../../util/apis";
+import { out } from "../../../util/interaction";
+import { inspect } from "util";
+
+const debug = require("debug")("appcenter-cli:commands:distribute:releases:delete");
+
+@help("Enables or disables specified release")
+export default class EditReleaseCommand extends AppCommand {
+  @help("Release ID")
+  @shortName("r")
+  @longName("release-id")
+  @required
+  @hasArg
+  public releaseId: string;
+
+  @help("Release state")
+  @name("State")
+  @position(0)
+  @required
+  public state: string;
+
+  public async run(client: AppCenterClient): Promise<CommandResult> {
+    const app = this.app;
+
+    const releaseId = Number(this.releaseId);
+    if (!Number.isSafeInteger(releaseId) || releaseId <= 0) {
+      return failure(ErrorCodes.InvalidParameter, `${this.releaseId} is not a valid release id`);
+    }
+
+    const state = this.state;
+    if (state !== "enabled" && state !== "disabled") {
+      return failure(ErrorCodes.InvalidParameter, `"${state}" is not a valid release state. Available states are "enabled" or "disabled".`);
+    }
+
+    let releaseDetails: models.ReleaseDetailsResponse;
+    try {
+      debug("Loading release details");
+      const httpRequest = await out.progress("Loading release details...", clientRequest<models.ReleaseDetailsResponse>(
+        (cb) => client.releases.getLatestByUser(this.releaseId, app.ownerName, app.appName, cb)
+      ));
+      if (httpRequest.response.statusCode >= 400) {
+        throw httpRequest.response.statusCode;
+      } else {
+        releaseDetails = httpRequest.result;
+      }
+    } catch (error) {
+      if (error === 404) {
+        return failure(ErrorCodes.InvalidParameter, `release ${this.releaseId} doesn't exist`);
+      } else {
+        debug(`Failed to load release details - ${inspect(error)}`);
+        return failure(ErrorCodes.Exception, "failed to load release details");
+      }
+    }
+
+    try {
+      debug(`Updating release state to "${state}"`);
+      const httpResponse = await out.progress(`${state === "enabled" ? "Enabling" : "Disabling"} the release...`,
+        clientRequest((cb) => client.releases.updateDetails(releaseId, app.ownerName, app.appName, { enabled: state === "enabled" }, cb)));
+      if (httpResponse.response.statusCode >= 400) {
+        throw httpResponse.result;
+      }
+    } catch (error) {
+      debug(`Failed to update the release - ${inspect(error)}`);
+      return failure(ErrorCodes.Exception, `failed to ${state === "enabled" ? "enable" : "disable"} the release`);
+    }
+
+    out.text(`Release ${releaseDetails.shortVersion} (${releaseDetails.version}) with id: ${this.releaseId} has been ${state}`);
+    return success();
+  }
+}

--- a/test/commands/distribute/releases/edit-test.ts
+++ b/test/commands/distribute/releases/edit-test.ts
@@ -1,0 +1,218 @@
+import { expect } from "chai";
+import * as Nock from "nock";
+import * as Temp from "temp";
+import * as _ from "lodash";
+
+import EditReleaseCommand from "../../../../src/commands/distribute/releases/edit";
+import { CommandArgs, CommandResult, CommandFailedResult } from "../../../../src/util/commandline";
+
+Temp.track();
+
+describe("distribute releases edit command", async () => {
+  const fakeAppOwner = "fakeAppOwner";
+  const fakeAppName = "fakeAppName";
+  const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;
+  const fakeToken = "c1o3d3e7";
+  const fakeReleaseId = "5";
+  /* tslint:disable-next-line:no-http-string */
+  const fakeHost = "http://localhost:1700";
+  const releaseIdOption = "--release-id";
+
+  before(() => {
+    Nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    Nock.cleanAll();
+  });
+
+  after(() => {
+    Nock.enableNetConnect();
+  });
+
+  context("completes successfully", () => {
+    it("if enable release", async () => {
+      // Arrange
+      const executionScope = _.flow(setupReleaseDetailsResponse, setupUpdateReleaseResponse)(Nock(fakeHost));
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, fakeReleaseId, "enabled"]));
+      const result = await command.execute();
+
+      testCommandSuccess(result, executionScope);
+    });
+
+    it("if disable release", async () => {
+      // Arrange
+      const executionScope = _.flow(setupReleaseDetailsResponse, setupUpdateReleaseResponse)(Nock(fakeHost));
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, fakeReleaseId, "disabled"]));
+      const result = await command.execute();
+
+      testCommandSuccess(result, executionScope);
+    });
+  });
+
+  context("failed", () => {
+    it("if --release-id option wasn't specified", async () => {
+      // Arrange
+      let errorMessage: string;
+      const expectedErrorMessage = "Missing required option -r / --release-id";
+
+      let command;
+      // Act
+      try {
+        command = new EditReleaseCommand(getCommandArgs([releaseIdOption]));
+      } catch (e) {
+        errorMessage = e.message;
+      }
+
+      // Assert
+      expect(errorMessage).to.eql(expectedErrorMessage);
+    });
+
+    it("if --release-id option value is not valid", async () => {
+      // Arrange
+      const expectedErrorMessage = "notanumber is not a valid release id";
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, "notanumber", "disabled"]));
+      const result = await command.execute();
+
+      // Assert
+      expect((result as CommandFailedResult).errorMessage).to.eql(expectedErrorMessage);
+    });
+
+    it("if state option wasn't specified", async () => {
+      // Arrange
+      let errorMessage: string;
+      const expectedErrorMessage = "Missing required positional argument State";
+
+      // Act
+      let command;
+      try {
+        command = new EditReleaseCommand(getCommandArgs([releaseIdOption, "1"]));
+      } catch (e) {
+        errorMessage = e.message;
+      }
+
+      // Assert
+      expect(errorMessage).to.eql(expectedErrorMessage);
+    });
+
+    it("if state option value is invalid", async () => {
+      // Arrange
+      const expectedErrorMessage = `"invalidvalue" is not a valid release state. Available states are "enabled" or "disabled".`;
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, "1", "invalidvalue"]));
+      const result = await command.execute();
+
+      // Assert
+      expect((result as CommandFailedResult).errorMessage).to.eql(expectedErrorMessage);
+    });
+
+    it("if release does not exist", async () => {
+      // Arrange
+      const expectedErrorMessage = `release ${fakeReleaseId} doesn't exist`;
+      const executionScope = setupReleaseDetailsNotFoundResponse(Nock(fakeHost));
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, fakeReleaseId, "disabled"]));
+      const result = await command.execute();
+
+      // Assert
+      expect((result as CommandFailedResult).errorMessage).to.eql(expectedErrorMessage);
+      testCommandFailure(executionScope);
+    });
+
+    it("if failed to load release details", async () => {
+      // Arrange
+      const expectedErrorMessage = "failed to load release details";
+      const executionScope = setupReleaseDetailsServiceUnavailableResponse(Nock(fakeHost));
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, fakeReleaseId, "disabled"]));
+      const result = await command.execute();
+
+      // Assert
+      expect((result as CommandFailedResult).errorMessage).to.eql(expectedErrorMessage);
+      testCommandFailure(executionScope);
+    });
+
+    it("if failed to update release state", async () => {
+      // Arrange
+      const expectedErrorMessage = "failed to disable the release";
+      const executionScope = _.flow(setupReleaseDetailsResponse, setupUpdateReleaseServiceUnavailableResponse)(Nock(fakeHost));
+
+      // Act
+      const command = new EditReleaseCommand(getCommandArgs([releaseIdOption, fakeReleaseId, "disabled"]));
+      const result = await command.execute();
+
+      // Assert
+      expect((result as CommandFailedResult).errorMessage).to.eql(expectedErrorMessage);
+      testCommandFailure(executionScope);
+    });
+  });
+
+  function testCommandSuccess(result: CommandResult, executionScope: Nock.Scope, abortScope?: Nock.Scope) {
+    expect(result.succeeded).to.eql(true, "Command should be successfully completed");
+    if (abortScope) {
+      expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    }
+    executionScope.done(); // All normal API calls are executed
+  }
+
+  function testCommandFailure(executionScope: Nock.Scope, abortScope?: Nock.Scope) {
+    if (abortScope) {
+      expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    }
+    executionScope.done(); // All normal API calls are executed
+  }
+
+  function getCommandArgs(additionalArgs: string[]): CommandArgs {
+    const args: string[] = ["-a", fakeAppIdentifier, "--token", fakeToken, "--env", "local"].concat(additionalArgs);
+    return {
+      args,
+      command: ["distribute", "releases", "edit"],
+      commandPath: "FAKE_COMMAND_PATH"
+    };
+  }
+
+  function setupReleaseDetailsNotFoundResponse(nockScope: Nock.Scope) {
+    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`)
+      .reply(404, {
+        error: {
+          code: "NotFound",
+          message: `Could not find release with id ${fakeReleaseId}`
+        }
+      });
+  }
+
+  function setupReleaseDetailsResponse(nockScope: Nock.Scope) {
+    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`)
+      .reply(200, {
+        shortVersion: "1.1",
+        version: "1.1"
+      });
+  }
+
+  function setupReleaseDetailsServiceUnavailableResponse(nockScope: Nock.Scope) {
+    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`)
+      .reply(400);
+  }
+
+  function setupUpdateReleaseServiceUnavailableResponse(nockScope: Nock.Scope) {
+    return nockScope.put(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`)
+      .reply(400);
+  }
+
+  function setupUpdateReleaseResponse(nockScope: Nock.Scope) {
+    return nockScope.put(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`)
+      .reply(200, {
+        shortVersion: "1.1",
+        version: "1.1"
+      });
+  }
+});


### PR DESCRIPTION
This PR will add the `distribute releases edit` command which allows to enable or disable a release.

```
appcenter-cli (edit-release) » ./bin/appcenter.js distribute releases edit --help                                                                                                                            ~/work/microsoft/appcenter-cli

Enables or disables specified release

Usage: appcenter distribute releases edit -r|--release-id <arg> [-a|--app <arg>] <State>

Options:
    -r|--release-id <arg>             Release ID
    -a|--app <arg>                    Specify app in the <ownerName>/<appName> format
    State                             Release state
```