### PR TITLE
Stdover/show all destination

### DIFF
--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -1,9 +1,8 @@
 import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg } from "../../../util/commandline";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { out } from "../../../util/interaction";
-import { inspect, } from "util";
+import { inspect } from "util";
 import * as _ from "lodash";
-import { release } from "os";
 
 const debug = require("debug")("appcenter-cli:commands:distribute:releases:show");
 

--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -17,7 +17,6 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const app = this.app;
-    
     const releaseId = Number(this.releaseId);
     const noDestinations = `The release with id ${releaseId} does not have any release destinations.`;
     if (!Number.isSafeInteger(releaseId) || releaseId <= 0) {

--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -17,6 +17,7 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const app = this.app;
+    
     const releaseId = Number(this.releaseId);
     const noDestinations = `The release with id ${releaseId} does not have any release destinations.`;
     if (!Number.isSafeInteger(releaseId) || releaseId <= 0) {

--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -1,8 +1,9 @@
 import { AppCommand, CommandResult, ErrorCodes, failure, help, success, shortName, longName, required, hasArg } from "../../../util/commandline";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { out } from "../../../util/interaction";
-import { inspect } from "util";
+import { inspect, } from "util";
 import * as _ from "lodash";
+import { release } from "os";
 
 const debug = require("debug")("appcenter-cli:commands:distribute:releases:show");
 
@@ -17,8 +18,8 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const app = this.app;
-
     const releaseId = Number(this.releaseId);
+    const noDestinations = `The release with id ${releaseId} does not have any release destinations.`;
     if (!Number.isSafeInteger(releaseId) || releaseId <= 0) {
       return failure(ErrorCodes.InvalidParameter, `${this.releaseId} is not a valid release id`);
     }
@@ -43,8 +44,6 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
       }
     }
 
-    const noDestinations = `The release with id ${releaseId} does not have any release destinations.`;
-
     out.report([
       ["ID", "id"],
       ["Status", "status"],
@@ -63,7 +62,7 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
       ["Download URL", "downloadUrl"],
       ["Install URL", "installUrl"],
       ["Icon URL", "appIconUrl"],
-      ["Destinations", "destinations", (destinations: models.Destination[]) => destinations && destinations.length > 1 ? JSON.stringify(destinations) : noDestinations]
+      ["Destinations", "destinations", (destinations: models.Destination[]) => destinations && destinations.length > 1 ? JSON.stringify(destinations, null, 2) : noDestinations]
     ], releaseDetails);
 
     return success();

--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -61,7 +61,7 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
       ["Download URL", "downloadUrl"],
       ["Install URL", "installUrl"],
       ["Icon URL", "appIconUrl"],
-      ["Distribution Group", "distributionGroups", (distributionGroups: models.DistributionGroup[]) => _.get(distributionGroups, "[0].name", "")]
+      ["Destinations", "destinations", (destinations: models.Destination[]) => JSON.stringify(destinations)]
     ], releaseDetails);
 
     return success();

--- a/src/commands/distribute/releases/show.ts
+++ b/src/commands/distribute/releases/show.ts
@@ -43,6 +43,8 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
       }
     }
 
+    const noDestinations = `The release with id ${releaseId} does not have any release destinations.`;
+
     out.report([
       ["ID", "id"],
       ["Status", "status"],
@@ -61,7 +63,7 @@ export default class ShowReleaseDetailsCommand extends AppCommand {
       ["Download URL", "downloadUrl"],
       ["Install URL", "installUrl"],
       ["Icon URL", "appIconUrl"],
-      ["Destinations", "destinations", (destinations: models.Destination[]) => JSON.stringify(destinations)]
+      ["Destinations", "destinations", (destinations: models.Destination[]) => destinations && destinations.length > 1 ? JSON.stringify(destinations) : noDestinations]
     ], releaseDetails);
 
     return success();

--- a/test/commands/distribute/releases/show-test.ts
+++ b/test/commands/distribute/releases/show-test.ts
@@ -44,7 +44,7 @@ describe("releases show command", () => {
     Nock.enableNetConnect();
   });
 
-  describe.only("when everything works as expected", () => {
+  describe("when everything works as expected", () => {
     const destinations: Destination[] = [
       {
         name: "destination 1",


### PR DESCRIPTION
View all release destinations via the CLI: Users can now view all destinations, including Testers, Distribution Groups, and Stores when viewing the release using the CLI

+ Added a message to display when there are no release destinations.
+ Showing all destinations for a release
