### PR TITLE
Release v1.1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter codepush patch` | Update the metadata for an existing CodePush release |
 | `appcenter codepush promote` | Create a new release for the destination deployment, which includes the exact code and metadata from the latest release of the source deployment |
 | `appcenter codepush release-cordova` | Release a Cordova update to an app deployment |
-| `appcenter codepush release-electron` | Release a Electron update to an deployment |
+| `appcenter codepush release-electron` | Release an Electron update to a deployment |
 | `appcenter codepush release-react` | Release a React Native update to an app deployment |
 | `appcenter codepush release` | Release an update to an app deployment |
 | `appcenter codepush rollback` | Rollback a deployment to a previous release |
@@ -80,11 +80,11 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter distribute groups list` | Lists all distribution groups of the app |
 | `appcenter distribute groups show` | Shows information about the distribution group |
 | `appcenter distribute groups update` | Update existing distribution group |
+| `appcenter distribute releases add-destination` | Distributes an existing release to an additional destination |
 | `appcenter distribute releases delete` | Deletes the release |
+| `appcenter distribute releases edit` | Toggles enabling and disabling the specified release |
 | `appcenter distribute releases list` | Shows the list of all releases for the application |
 | `appcenter distribute releases show` | Shows full details about release |
-| `appcenter distribute releases edit` | Enables/disables the release |
-| `appcenter distribute releases add-destination` | Distributes an existing release to an additional destination |
 | | |
 | `appcenter orgs create` | Create a new organization |
 | `appcenter orgs list` | Lists organizations in which current user is collaborator |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
- Upgrades API calls for distribute command to use non-depreciated calls
- Adds `distribute releases edit` command to enable and disable releases
- Displays all release destinations from `show` command
- Adds `distribute releases add-destination` command to allow users to add destinations to a release
- Makes CodePush Release Electron consistent with CodePush Release ReactNative by using the same switch for SourceMap as well as providing a new option for SourceMapOutputDir.
- Adds WebPack-CLI as Dependency, so it's packaged in the node_modules for use by CodePush Release Electron option