### PR TITLE
Fix getting symbol groups

### DIFF
--- a/src/commands/crashes/upload-missing-symbols.ts
+++ b/src/commands/crashes/upload-missing-symbols.ts
@@ -22,6 +22,8 @@ import * as ChildProcess from "child_process";
 const debug = require("debug")("appcenter-cli:commands:apps:crashes:upload-missing-symbols");
 const bplist = require("bplist");
 
+const MAX_SQL_INTEGER = 2147483647;
+
 @help("Upload missing crash symbols for the application (only from macOS)")
 export default class UploadMissingSymbols extends AppCommand {
   @help("Path to a dSYM package or a directory containing dSYM packages")
@@ -69,7 +71,7 @@ export default class UploadMissingSymbols extends AppCommand {
 
   private async getMissingSymbolsIds(client: AppCenterClient, app: DefaultApp): Promise<string[]> {
     try {
-      const httpResponse = await clientRequest<models.V2MissingSymbolCrashGroupsResponse>((cb) => client.missingSymbolGroups.list(Number.MAX_SAFE_INTEGER, app.ownerName, app.appName, cb));
+      const httpResponse = await clientRequest<models.V2MissingSymbolCrashGroupsResponse>((cb) => client.missingSymbolGroups.list(MAX_SQL_INTEGER, app.ownerName, app.appName, cb));
       return _.flatten(httpResponse.result.groups
         .map((crashGroup) => crashGroup.missingSymbols.filter((s) => s.status === "missing").map((s) => s.symbolId)));
     } catch (error) {


### PR DESCRIPTION
At the moment, when sending a request to get the symbol groups for an app, we are sending a `top` parameter of the value `Number.MAX_SAFE_INTEGER`.

Unfortunately this number is 9007199254740991 - which is way larger than the value accepted by the backend data store used by the symbol indexing service.

I’ve changed it to use a 32 bit integer to fix this issue.