### PR TITLE
Add source-version argument to the build queue command

### DIFF
--- a/src/commands/build/queue.ts
+++ b/src/commands/build/queue.ts
@@ -9,7 +9,7 @@ const debug = require("debug")("appcenter-cli:commands:build:queue");
 @help("Queue a new build")
 export default class QueueBuildCommand extends AppCommand {
 
-  @help("Branch to be build")
+  @help("Branch to be built")
   @shortName("b")
   @longName("branch")
   @required

--- a/src/commands/build/queue.ts
+++ b/src/commands/build/queue.ts
@@ -21,6 +21,12 @@ export default class QueueBuildCommand extends AppCommand {
   @longName("debug-logs")
   public debugLogs: boolean;
 
+  @help("Source control version reference")
+  @shortName("s")
+  @longName("source-version")
+  @hasArg
+  public sourceVersion: string;  
+
   async run(client: AppCenterClient, portalBaseUrl: string): Promise<CommandResult> {
     const app = this.app;
 
@@ -29,7 +35,8 @@ export default class QueueBuildCommand extends AppCommand {
     try {
       queueBuildRequestResponse = await out.progress(`Queueing build for branch ${this.branchName}...`,
         clientRequest<models.Build>((cb) => client.builds.create(this.branchName, app.ownerName, app.appName, {
-          debug: this.debugLogs
+          debug: this.debugLogs,
+          sourceVersion: this.sourceVersion
         }, cb)));
     } catch (error) {
       if (error.statusCode === 400) {

--- a/src/commands/build/queue.ts
+++ b/src/commands/build/queue.ts
@@ -25,7 +25,7 @@ export default class QueueBuildCommand extends AppCommand {
   @shortName("s")
   @longName("source-version")
   @hasArg
-  public sourceVersion: string;  
+  public sourceVersion: string;
 
   async run(client: AppCenterClient, portalBaseUrl: string): Promise<CommandResult> {
     const app = this.app;


### PR DESCRIPTION
Whenever my company increments the version of our app, we trigger a build on AppCenter which works great. The issue this PR aims to solve is that once the build is complete, the notification we get in Slack does not include the version notes that are in the commit message. I've asked about getting this fixed on the AppCenter Intercom for a while now but was told that its unfortunately not a priority. Jihye did mention there is a temporary fix possible by manually making the API POST to AppCenter's API and including the `sourceVersion` argument  as seen here: https://openapi.appcenter.ms/#/build/builds_create

This works great so this PR adds the `sourceVersion` argument to the `build queue` command so it is possible as a workaround for now until AppCenter is able to pick up the commit message that triggered the build automatically.

Thanks and let me know if there are any required changes to this PR!

Cody Brouwers