### PR TITLE
Fix typo

### DIFF
--- a/src/commands/analytics/category.txt
+++ b/src/commands/analytics/category.txt
@@ -1,1 +1,1 @@
-View events, audience info, sessions, and other anayltics for apps
+View events, audience info, sessions, and other analytics for apps


### PR DESCRIPTION
Fix typo in `src/commands/analytics/category.txt`: `anayltics` -> `analytics`