### PR TITLE
Add warning for poor target-binary-version in codepush

### DIFF
--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -151,7 +151,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
     const warningVersion = generateWarningVersionForPoorVersionIfNeeded(version);
 
     if (warningVersion) {
-      out.text(`\nYour target-binary-version "${version}" will be treated as "${warningVersion}"\n`);
+      out.text(`\nYour target-binary-version "${version}" will be treated as "${warningVersion}".\n`);
     }
   }
 

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -10,7 +10,7 @@ import * as chalk from "chalk";
 import { sign, zip } from "../lib/update-contents-tasks";
 import { isBinaryOrZip, getLastFolderInPath, moveReleaseFilesInTmpFolder, isDirectory } from "../lib/file-utils";
 import { environments } from "../lib/environment";
-import { isValidRange, isValidRollout, isValidDeployment } from "../lib/validation-utils";
+import { isValidRange, isValidRollout, isValidDeployment, generateWarningVersionForPoorVersionIfNeeded } from "../lib/validation-utils";
 import { LegacyCodePushRelease }  from "../lib/release-strategy/index";
 import { getTokenFromEnvironmentVar } from "../../../util/profile/environment-vars";
 
@@ -117,6 +117,8 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       const serverUrl = this.getServerUrl();
       const token = this.token || getTokenFromEnvironmentVar() || await getUser().accessToken;
 
+      this.printWarningForPoorTargetBinaryVersionIfNeeded(this.targetBinaryVersion);
+
       await out.progress("Creating CodePush release...",  this.releaseStrategy.release(client, app, this.deploymentName, updateContentsZipPath, {
         appVersion: this.targetBinaryVersion,
         description: this.description,
@@ -142,6 +144,14 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       }
     } finally {
       await pfs.rmDir(updateContentsZipPath);
+    }
+  }
+
+  private printWarningForPoorTargetBinaryVersionIfNeeded(version: string): void {
+    const warningVersion = generateWarningVersionForPoorVersionIfNeeded(version);
+
+    if (warningVersion) {
+      out.text(`\nYour target-binary-version "${version}" will be treated as "${warningVersion}"\n`);
     }
   }
 

--- a/src/commands/codepush/lib/release-command-skeleton.ts
+++ b/src/commands/codepush/lib/release-command-skeleton.ts
@@ -10,7 +10,7 @@ import * as chalk from "chalk";
 import { sign, zip } from "../lib/update-contents-tasks";
 import { isBinaryOrZip, getLastFolderInPath, moveReleaseFilesInTmpFolder, isDirectory } from "../lib/file-utils";
 import { environments } from "../lib/environment";
-import { isValidRange, isValidRollout, isValidDeployment, generateWarningVersionForPoorVersionIfNeeded } from "../lib/validation-utils";
+import { isValidRange, isValidRollout, isValidDeployment, validateVersion } from "../lib/validation-utils";
 import { LegacyCodePushRelease }  from "../lib/release-strategy/index";
 import { getTokenFromEnvironmentVar } from "../../../util/profile/environment-vars";
 
@@ -117,7 +117,7 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
       const serverUrl = this.getServerUrl();
       const token = this.token || getTokenFromEnvironmentVar() || await getUser().accessToken;
 
-      this.printWarningForPoorTargetBinaryVersionIfNeeded(this.targetBinaryVersion);
+      this.checkTargetBinaryVersion(this.targetBinaryVersion);
 
       await out.progress("Creating CodePush release...",  this.releaseStrategy.release(client, app, this.deploymentName, updateContentsZipPath, {
         appVersion: this.targetBinaryVersion,
@@ -147,8 +147,8 @@ export default class CodePushReleaseCommandSkeleton extends AppCommand {
     }
   }
 
-  private printWarningForPoorTargetBinaryVersionIfNeeded(version: string): void {
-    const warningVersion = generateWarningVersionForPoorVersionIfNeeded(version);
+  private checkTargetBinaryVersion(version: string): void {
+    const warningVersion = validateVersion(version);
 
     if (warningVersion) {
       out.text(`\nYour target-binary-version "${version}" will be treated as "${warningVersion}".\n`);

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -2,10 +2,13 @@ import * as semver from "semver";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 
+const regexpForMajor = /^\d+$/;
+const regexpForMajorMinor = /^\d+\.\d+$/;
+
 // Check if the given string is a semver-compliant version number (e.g. '1.2.3')
 // (missing minor/patch values will be added on server side to pass semver.satisfies check)
 export function isValidVersion(version: string): boolean {
-  return !!semver.valid(version) || /^\d+\.\d+$/.test(version) || /^\d+$/.test(version);
+  return !!semver.valid(version) || regexpForMajorMinor.test(version) || regexpForMajor.test(version);
 }
 
 // Allow plain integer versions (as well as '1.0' values) for now, e.g. '1' is valid here and we assume that it is equal to '1.0.0'.
@@ -22,4 +25,14 @@ export async function isValidDeployment(client: AppCenterClient, app: DefaultApp
     (cb) => client.codePushDeployments.get(deploymentName, app.ownerName, app.appName, cb));
 
   return httpRequest.response.statusCode === 200 ? Promise.resolve(true) : Promise.resolve(false);
+}
+
+export function generateWarningVersionForPoorVersionIfNeeded(version: string): string {
+  if (regexpForMajorMinor.test(version)) {
+    return version + ".X"
+  } else if (regexpForMajor.test(version)) {
+    return version + ".X.X";
+  } else {
+    return null;
+  }
 }

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -29,7 +29,7 @@ export async function isValidDeployment(client: AppCenterClient, app: DefaultApp
 
 export function generateWarningVersionForPoorVersionIfNeeded(version: string): string {
   if (regexpForMajorMinor.test(version)) {
-    return version + ".X"
+    return version + ".X";
   } else if (regexpForMajor.test(version)) {
     return version + ".X.X";
   } else {

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -27,7 +27,7 @@ export async function isValidDeployment(client: AppCenterClient, app: DefaultApp
   return httpRequest.response.statusCode === 200 ? Promise.resolve(true) : Promise.resolve(false);
 }
 
-export function generateWarningVersionForPoorVersionIfNeeded(version: string): string {
+export function validateVersion(version: string): string {
   if (regexpForMajorMinor.test(version)) {
     return version + ".X";
   } else if (regexpForMajor.test(version)) {

--- a/test/commands/codepush/lib/validation-utils-test.ts
+++ b/test/commands/codepush/lib/validation-utils-test.ts
@@ -1,4 +1,4 @@
-import { isValidVersion, isValidRange } from "../../../../src/commands/codepush/lib/validation-utils";
+import { isValidVersion, isValidRange, generateWarningVersionForPoorVersionIfNeeded } from "../../../../src/commands/codepush/lib/validation-utils";
 import { expect } from "chai";
 
 describe("isValidVersion", function () {
@@ -90,6 +90,52 @@ describe("isValidRange", function () {
     it("returns false", function () {
       for (const range of invalidRanges) {
         expect(isValidRange(range)).to.be.false;
+      }
+    });
+  });
+});
+
+describe("generateWarningVersionForPoorVersionIfNeeded", function () {
+  context("when a given version contains only major number", function () {
+    const semverCompliantRanges = [
+      "1",
+      "123"
+    ];
+    const addedMinorPatchNumbers = ".X.X";
+
+    it("returns generated warning version", function () {
+      for (const range of semverCompliantRanges) {
+        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(range + addedMinorPatchNumbers);
+      }
+    });
+  });
+
+  context("when a given version contains only major and minor number", function () {
+    const semverCompliantRanges = [
+      "1.0",
+      "123.456"
+    ];
+    const addedMinorPatchNumbers = ".X";
+
+    it("returns generated warning version", function () {
+      for (const range of semverCompliantRanges) {
+        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(range + addedMinorPatchNumbers);
+      }
+    });
+  });
+
+  context("when a given version is full or range", function () {
+    const semverCompliantRanges = [
+      "1.0.0",
+      "123.456.789",
+      "'*'",
+      "'1.2.3 - 1.2.7'",
+      "'>=1.2.3 <1.2.7'"
+    ];
+
+    it("returns 'null'", function () {
+      for (const range of semverCompliantRanges) {
+        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(null);
       }
     });
   });

--- a/test/commands/codepush/lib/validation-utils-test.ts
+++ b/test/commands/codepush/lib/validation-utils-test.ts
@@ -1,4 +1,4 @@
-import { isValidVersion, isValidRange, generateWarningVersionForPoorVersionIfNeeded } from "../../../../src/commands/codepush/lib/validation-utils";
+import { isValidVersion, isValidRange, validateVersion } from "../../../../src/commands/codepush/lib/validation-utils";
 import { expect } from "chai";
 
 describe("isValidVersion", function () {
@@ -95,7 +95,7 @@ describe("isValidRange", function () {
   });
 });
 
-describe("generateWarningVersionForPoorVersionIfNeeded", function () {
+describe("validateVersion", function () {
   context("when a given version contains only major number", function () {
     const semverCompliantRanges = [
       "1",
@@ -105,7 +105,7 @@ describe("generateWarningVersionForPoorVersionIfNeeded", function () {
 
     it("returns generated warning version", function () {
       for (const range of semverCompliantRanges) {
-        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(range + addedMinorPatchNumbers);
+        expect(validateVersion(range)).to.equal(range + addedMinorPatchNumbers);
       }
     });
   });
@@ -119,7 +119,7 @@ describe("generateWarningVersionForPoorVersionIfNeeded", function () {
 
     it("returns generated warning version", function () {
       for (const range of semverCompliantRanges) {
-        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(range + addedMinorPatchNumbers);
+        expect(validateVersion(range)).to.equal(range + addedMinorPatchNumbers);
       }
     });
   });
@@ -135,7 +135,7 @@ describe("generateWarningVersionForPoorVersionIfNeeded", function () {
 
     it("returns 'null'", function () {
       for (const range of semverCompliantRanges) {
-        expect(generateWarningVersionForPoorVersionIfNeeded(range)).to.equal(null);
+        expect(validateVersion(range)).to.equal(null);
       }
     });
   });


### PR DESCRIPTION
*Issue:* In case if a user specifies not full `--target-binary-version` like `1.0` or `1` then it will be treated as `1.0.X` and `1.X.X` on server side. It can confuse some users.

*Solution:* Added warning for this cases.

Screenshot:
![image](https://user-images.githubusercontent.com/13234108/59928403-50298d00-9447-11e9-9412-1dde24d56f7d.png)

Related issue: https://github.com/microsoft/code-push/issues/605