### PR TITLE
Bumps the minimum node version to 10.x

### DIFF
--- a/bin/appcenter.js
+++ b/bin/appcenter.js
@@ -3,8 +3,8 @@
 var util = require('util');
 
 // Verify user has minimum required version of node installed
-var minMajorVersion = 6;
-var minMinorVersion = 3;
+var minMajorVersion = 10;
+var minMinorVersion = 0;
 
 function getCurrentVersion() {
   var matches = process.version.match(/v?(\d+)\.(\d+)\.(\d+)/);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "homepage": "https://github.com/Microsoft/appcenter-cli#readme",
   "engine": {
-    "node": ">=6.3.0"
+    "node": ">=10.0.0"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
### Motivation

It's confusing when the `appcenter-cli` errors out with unhelpful parse errors. This will let users know that they need to use node 10.x in a more friendly way.

Output:

```
appcenter help
appcenter command requires at least node version 10.0.0.
You are currently running version v8.4.0.
Please upgrade your version of node.js to at least 10.0.0
```