### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
- Reinstates node 10 restriction on major release bump.