### PR TITLE
Added build_version optional parameter to CLI release command

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -20,6 +20,12 @@ export default class ReleaseBinaryCommand extends AppCommand {
   @hasArg
   public filePath: string;
 
+  @help("Build version parameter required for .zip and .msi files")
+  @shortName("b")
+  @longName("build-version")
+  @hasArg
+  public buildVersion: string;
+
   @help("Distribution group name")
   @shortName("g")
   @longName("group")

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -178,7 +178,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
     let createReleaseUploadRequestResponse: ClientResponse<models.ReleaseUploadBeginResponse>;
     try {
       createReleaseUploadRequestResponse = await out.progress("Creating release upload...",
-        clientRequest<models.ReleaseUploadBeginResponse>((cb) => client.releaseUploads.create(app.ownerName, app.appName, cb)));
+        clientRequest<models.ReleaseUploadBeginResponse>((cb) => client.releaseUploads.create(app.ownerName, app.appName, { buildVersion: this.buildVersion }, cb)));
     } catch (error) {
       throw failure(ErrorCodes.Exception, `failed to create release upload for ${this.filePath}`);
     }

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -103,6 +103,12 @@ export default class ReleaseBinaryCommand extends AppCommand {
     if (!_.isNil(this.releaseNotes) && !_.isNil(this.releaseNotesFile)) {
       throw failure(ErrorCodes.InvalidParameter, "'--release-notes' and '--release-notes-file' switches are mutually exclusive");
     }
+    if (_.isNil(this.buildVersion)) {
+      const extension = this.filePath.substring(this.filePath.lastIndexOf(".")).toLowerCase();
+      if ([".zip", ".msi"].includes(extension)) {
+        throw failure(ErrorCodes.InvalidParameter, "--build-version parameter must be specified when uploading .zip or .msi file");
+      }
+    }
   }
 
   private getPrerequisites(client: AppCenterClient): Promise<[number | null, Buffer, string]> {

--- a/src/util/apis/generated/models/index.d.ts
+++ b/src/util/apis/generated/models/index.d.ts
@@ -4173,6 +4173,10 @@ export interface ReleaseUploadBeginRequest {
    * The ID of the release.
   */
   releaseId?: number;
+  /**
+   * The build version of the uploaded WPF/Winforms
+  */
+  buildVersion?: string;
 }
 
 /**

--- a/src/util/apis/generated/models/index.d.ts
+++ b/src/util/apis/generated/models/index.d.ts
@@ -4174,7 +4174,7 @@ export interface ReleaseUploadBeginRequest {
   */
   releaseId?: number;
   /**
-   * The build version of the uploaded WPF/Winforms
+   * The build version of the uploaded binary
   */
   buildVersion?: string;
 }

--- a/src/util/apis/generated/models/releaseUploadBeginRequest.js
+++ b/src/util/apis/generated/models/releaseUploadBeginRequest.js
@@ -19,6 +19,8 @@ class ReleaseUploadBeginRequest {
   /**
    * Create a ReleaseUploadBeginRequest.
    * @property {number} [releaseId] The ID of the release.
+   * @property {string} [buildVersion] The build version of the uploaded
+   * WPF/Winforms
    */
   constructor() {
   }
@@ -42,6 +44,13 @@ class ReleaseUploadBeginRequest {
             serializedName: 'release_id',
             type: {
               name: 'Number'
+            }
+          },
+          buildVersion: {
+            required: false,
+            serializedName: 'build_version',
+            type: {
+              name: 'String'
             }
           }
         }

--- a/src/util/apis/generated/models/releaseUploadBeginRequest.js
+++ b/src/util/apis/generated/models/releaseUploadBeginRequest.js
@@ -19,8 +19,7 @@ class ReleaseUploadBeginRequest {
   /**
    * Create a ReleaseUploadBeginRequest.
    * @property {number} [releaseId] The ID of the release.
-   * @property {string} [buildVersion] The build version of the uploaded
-   * WPF/Winforms
+   * @property {string} [buildVersion] The build version of the uploaded binary
    */
   constructor() {
   }

--- a/src/util/apis/generated/operations/index.d.ts
+++ b/src/util/apis/generated/operations/index.d.ts
@@ -13828,7 +13828,7 @@ export interface ReleaseUploads {
      * @param {number} [options.releaseId] The ID of the release.
      *
      * @param {string} [options.buildVersion] The build version of the uploaded
-     * WPF/Winforms
+     * binary
      *
      * @param {object} [options.customHeaders] Headers that will be added to the
      * request
@@ -13853,7 +13853,7 @@ export interface ReleaseUploads {
      * @param {number} [options.releaseId] The ID of the release.
      *
      * @param {string} [options.buildVersion] The build version of the uploaded
-     * WPF/Winforms
+     * binary
      *
      * @param {object} [options.customHeaders] Headers that will be added to the
      * request

--- a/src/util/apis/generated/operations/index.d.ts
+++ b/src/util/apis/generated/operations/index.d.ts
@@ -13827,6 +13827,9 @@ export interface ReleaseUploads {
      *
      * @param {number} [options.releaseId] The ID of the release.
      *
+     * @param {string} [options.buildVersion] The build version of the uploaded
+     * WPF/Winforms
+     *
      * @param {object} [options.customHeaders] Headers that will be added to the
      * request
      *
@@ -13836,7 +13839,7 @@ export interface ReleaseUploads {
      *
      * @reject {Error|ServiceError} - The error object.
      */
-    createWithHttpOperationResponse(ownerName: string, appName: string, options?: { releaseId? : number, customHeaders? : { [headerName: string]: string; } }): Promise<HttpOperationResponse<models.ReleaseUploadBeginResponse>>;
+    createWithHttpOperationResponse(ownerName: string, appName: string, options?: { releaseId? : number, buildVersion? : string, customHeaders? : { [headerName: string]: string; } }): Promise<HttpOperationResponse<models.ReleaseUploadBeginResponse>>;
 
     /**
      * Begins the upload process for a new release for the specified application.
@@ -13848,6 +13851,9 @@ export interface ReleaseUploads {
      * @param {object} [options] Optional Parameters.
      *
      * @param {number} [options.releaseId] The ID of the release.
+     *
+     * @param {string} [options.buildVersion] The build version of the uploaded
+     * WPF/Winforms
      *
      * @param {object} [options.customHeaders] Headers that will be added to the
      * request
@@ -13875,9 +13881,9 @@ export interface ReleaseUploads {
      *
      *                      {http.IncomingMessage} [response] - The HTTP Response stream if an error did not occur.
      */
-    create(ownerName: string, appName: string, options?: { releaseId? : number, customHeaders? : { [headerName: string]: string; } }): Promise<models.ReleaseUploadBeginResponse>;
+    create(ownerName: string, appName: string, options?: { releaseId? : number, buildVersion? : string, customHeaders? : { [headerName: string]: string; } }): Promise<models.ReleaseUploadBeginResponse>;
     create(ownerName: string, appName: string, callback: ServiceCallback<models.ReleaseUploadBeginResponse>): void;
-    create(ownerName: string, appName: string, options: { releaseId? : number, customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<models.ReleaseUploadBeginResponse>): void;
+    create(ownerName: string, appName: string, options: { releaseId? : number, buildVersion? : string, customHeaders? : { [headerName: string]: string; } }, callback: ServiceCallback<models.ReleaseUploadBeginResponse>): void;
 }
 
 /**

--- a/src/util/apis/generated/operations/releaseUploads.js
+++ b/src/util/apis/generated/operations/releaseUploads.js
@@ -178,6 +178,9 @@ function _complete(uploadId, ownerName, appName, status, options, callback) {
  *
  * @param {number} [options.releaseId] The ID of the release.
  *
+ * @param {string} [options.buildVersion] The build version of the uploaded
+ * WPF/Winforms
+ *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
  *
@@ -206,6 +209,7 @@ function _create(ownerName, appName, options, callback) {
     throw new Error('callback cannot be null.');
   }
   let releaseId = (options && options.releaseId !== undefined) ? options.releaseId : undefined;
+  let buildVersion = (options && options.buildVersion !== undefined) ? options.buildVersion : undefined;
   // Validate
   try {
     if (ownerName === null || ownerName === undefined || typeof ownerName.valueOf() !== 'string') {
@@ -217,13 +221,17 @@ function _create(ownerName, appName, options, callback) {
     if (releaseId !== null && releaseId !== undefined && typeof releaseId !== 'number') {
       throw new Error('releaseId must be of type number.');
     }
+    if (buildVersion !== null && buildVersion !== undefined && typeof buildVersion.valueOf() !== 'string') {
+      throw new Error('buildVersion must be of type string.');
+    }
   } catch (error) {
     return callback(error);
   }
   let body;
-  if (releaseId !== null && releaseId !== undefined) {
+  if ((releaseId !== null && releaseId !== undefined) || (buildVersion !== null && buildVersion !== undefined)) {
     body = new client.models['ReleaseUploadBeginRequest']();
     body.releaseId = releaseId;
+    body.buildVersion = buildVersion;
   }
 
   // Construct URL
@@ -436,6 +444,9 @@ class ReleaseUploads {
    *
    * @param {number} [options.releaseId] The ID of the release.
    *
+   * @param {string} [options.buildVersion] The build version of the uploaded
+   * WPF/Winforms
+   *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
    *
@@ -469,6 +480,9 @@ class ReleaseUploads {
    * @param {object} [options] Optional Parameters.
    *
    * @param {number} [options.releaseId] The ID of the release.
+   *
+   * @param {string} [options.buildVersion] The build version of the uploaded
+   * WPF/Winforms
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request

--- a/src/util/apis/generated/operations/releaseUploads.js
+++ b/src/util/apis/generated/operations/releaseUploads.js
@@ -179,7 +179,7 @@ function _complete(uploadId, ownerName, appName, status, options, callback) {
  * @param {number} [options.releaseId] The ID of the release.
  *
  * @param {string} [options.buildVersion] The build version of the uploaded
- * WPF/Winforms
+ * binary
  *
  * @param {object} [options.customHeaders] Headers that will be added to the
  * request
@@ -445,7 +445,7 @@ class ReleaseUploads {
    * @param {number} [options.releaseId] The ID of the release.
    *
    * @param {string} [options.buildVersion] The build version of the uploaded
-   * WPF/Winforms
+   * binary
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request
@@ -482,7 +482,7 @@ class ReleaseUploads {
    * @param {number} [options.releaseId] The ID of the release.
    *
    * @param {string} [options.buildVersion] The build version of the uploaded
-   * WPF/Winforms
+   * binary
    *
    * @param {object} [options.customHeaders] Headers that will be added to the
    * request

--- a/swagger/bifrost.swagger.before.json
+++ b/swagger/bifrost.swagger.before.json
@@ -20578,6 +20578,10 @@
         "release_id": {
           "description": "The ID of the release.",
           "type": "number"
+        },
+        "build_version": {
+          "description": "The build version of the uploaded WPF/Winforms",
+          "type": "string"
         }
       }
     },

--- a/swagger/bifrost.swagger.before.json
+++ b/swagger/bifrost.swagger.before.json
@@ -20580,7 +20580,7 @@
           "type": "number"
         },
         "build_version": {
-          "description": "The build version of the uploaded WPF/Winforms",
+          "description": "The build version of the uploaded binary",
           "type": "string"
         }
       }

--- a/swagger/bifrost.swagger.json
+++ b/swagger/bifrost.swagger.json
@@ -20254,6 +20254,10 @@
         "release_id": {
           "description": "The ID of the release.",
           "type": "number"
+        },
+        "build_version": {
+          "description": "The build version of the uploaded WPF/Winforms",
+          "type": "string"
         }
       }
     },

--- a/swagger/bifrost.swagger.json
+++ b/swagger/bifrost.swagger.json
@@ -20256,7 +20256,7 @@
           "type": "number"
         },
         "build_version": {
-          "description": "The build version of the uploaded WPF/Winforms",
+          "description": "The build version of the uploaded binary",
           "type": "string"
         }
       }


### PR DESCRIPTION
**Why:** we need to support distribution of WinForms/WPF apps from .msi and .zip files
**What/How:** 
1. added `--build-version` extra parameter to `distribute release` command 
2. updated swagger (only build_version change and not the whole description from bifrost)
3. generated autorest models
4. passed the buildVersion to `release_uploads` endpoint call
