### PR TITLE
Add Hermes support to React Native Code Push CLI

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -2,9 +2,10 @@ import * as fs from "fs";
 import * as path from "path";
 import chalk from "chalk";
 import * as xml2js from "xml2js";
-import { out } from "../../../util/interaction";
+import { out, isDebug } from "../../../util/interaction";
 import { isValidVersion } from "./validation-utils";
 import { fileDoesNotExistOrIsDirectory } from "./file-utils";
+
 const plist = require("plist");
 const g2js = require("gradle-to-js/lib/parser");
 const properties = require("properties");
@@ -262,7 +263,11 @@ export function runHermesEmitBinaryCommand(bundleName: string, outputFolder: str
   ]);
 
   if (sourcemapOutput) {
-      hermesArgs.push("-output-source-map");
+    hermesArgs.push("-output-source-map");
+  }
+
+  if (!isDebug()) {
+    hermesArgs.push("-w");
   }
 
   out.text(chalk.cyan("Converting JS bundle to byte code via Hermes, running command:\n"));
@@ -275,7 +280,7 @@ export function runHermesEmitBinaryCommand(bundleName: string, outputFolder: str
       });
 
       hermesProcess.stderr.on("data", (data: Buffer) => {
-        // Since hermes is printing lots of messages on stderr, we skip anything here.
+        console.error(data.toString().trim());
       });
 
       hermesProcess.on("close", (exitCode: number) => {

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -246,6 +246,93 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
   });
 }
 
+export function runHermesEmitBinaryCommand(bundleName: string, outputFolder: string, sourcemapOutput: string, extraHermesOptions: string[]): Promise<void> {
+  const hermesArgs: string[] = [];
+  const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
+
+  if (typeof envNodeArgs !== "undefined") {
+      Array.prototype.push.apply(hermesArgs, envNodeArgs.trim().split(/\s+/));
+  }
+
+  Array.prototype.push.apply(hermesArgs, [
+      "-emit-binary",
+      "-out", path.join(outputFolder, bundleName + ".hbc"),
+      path.join(outputFolder, bundleName),
+      ...extraHermesOptions,
+  ]);
+
+  if (sourcemapOutput) {
+      hermesArgs.push("-output-source-map");
+  }
+
+  out.text(chalk.cyan("Converting JS bundle to byte code via Hermes, running command:\n"));
+  const hermesProcess = spawn(path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes"), hermesArgs);
+  out.text(`${path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes")} ${hermesArgs.join(" ")}`);
+
+  return new Promise<void>((resolve, reject) => {
+      hermesProcess.stdout.on("data", (data: Buffer) => {
+        out.text(data.toString().trim());
+      });
+
+      hermesProcess.stderr.on("data", (data: Buffer) => {
+        // Since hermes is printing lots of messages on stderr, we skip anything here.
+      });
+
+      hermesProcess.on("close", (exitCode: number) => {
+          if (exitCode) {
+              reject(new Error(`"hermes" command exited with code ${exitCode}.`));
+          }
+          // Copy HBC bundle to overwrite JS bundle
+          fs.copyFile(path.join(outputFolder, bundleName + ".hbc"), path.join(outputFolder, bundleName),
+            (err) => {
+              if (err) {
+                console.error(err);
+                reject(new Error(`"hermes" command exited with code ${exitCode}.`));
+              }
+              fs.unlinkSync(path.join(outputFolder, bundleName + ".hbc"));
+              resolve(null as void);
+            }
+          );
+      });
+  });
+}
+
+export function getHermesEnabled(gradleFile: string): boolean {
+  let buildGradlePath: string = path.join("android", "app");
+  if (gradleFile) {
+    buildGradlePath = gradleFile;
+  }
+  if (fs.lstatSync(buildGradlePath).isDirectory()) {
+    buildGradlePath = path.join(buildGradlePath, "build.gradle");
+  }
+
+  if (fileDoesNotExistOrIsDirectory(buildGradlePath)) {
+    throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
+  }
+
+  return g2js.parseFile(buildGradlePath)
+    .catch(() => {
+      throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
+    })
+    .then((buildGradle: any) => {
+      return Array.from(buildGradle["project.ext.react"]).includes("enableHermes: true");
+    });
+}
+
+function getHermesOSBin(): string {
+  switch (process.platform) {
+    case "win32":
+      return "win64-bin";
+    case "darwin":
+      return "osx-bin";
+    case "freebsd":
+    case "linux":
+    case "sunos":
+    default:
+      return "linux64-bin";
+  }
+}
+
 export function isValidOS(os: string): boolean {
   switch (os.toLowerCase()) {
     case "android":

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -77,7 +77,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
   @hasArg
   public extraBundlerOptions: string | string[];
 
-  @help("Flag that gets passed to Hermes, JavaScript to byte codecompiler. Can be specified multiple times")
+  @help("Flag that gets passed to Hermes, the JavaScript to byte codecompiler from Facebook. Can be specified multiple times")
   @longName("extra-hermes-flag")
   @defaultValue([])
   @hasArg

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -77,7 +77,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
   @hasArg
   public extraBundlerOptions: string | string[];
 
-  @help("Flag that gets passed to Hermes, the JavaScript to byte codecompiler from Facebook. Can be specified multiple times")
+  @help("Flag that gets passed to Hermes, JavaScript to bytecode compiler. Can be specified multiple times")
   @longName("extra-hermes-flag")
   @defaultValue([])
   @hasArg

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import * as mkdirp from "mkdirp";
 import { fileDoesNotExistOrIsDirectory, createEmptyTmpReleaseFolder, removeReactTmpDir } from "./lib/file-utils";
 import { isValidRange, isValidDeployment } from "./lib/validation-utils";
-import { VersionSearchParams, getReactNativeProjectAppVersion, runReactNativeBundleCommand, isValidOS, isValidPlatform, isReactNativeProject } from "./lib/react-native-utils";
+import { VersionSearchParams, getReactNativeProjectAppVersion, runReactNativeBundleCommand, runHermesEmitBinaryCommand, getHermesEnabled, isValidOS, isValidPlatform, isReactNativeProject } from "./lib/react-native-utils";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:release-react");
 
@@ -76,6 +76,12 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
   @defaultValue([])
   @hasArg
   public extraBundlerOptions: string | string[];
+
+  @help("Flag that gets passed to Hermes, JavaScript to byte codecompiler. Can be specified multiple times")
+  @longName("extra-hermes-flag")
+  @defaultValue([])
+  @hasArg
+  public extraHermesFlags: string | string[];
 
   private os: string;
 
@@ -160,11 +166,21 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandS
       this.extraBundlerOptions = [this.extraBundlerOptions];
     }
 
+    if (typeof this.extraHermesFlags === "string") {
+      this.extraHermesFlags = [this.extraHermesFlags];
+    }
+
     try {
       createEmptyTmpReleaseFolder(this.updateContentsPath);
       removeReactTmpDir();
       await runReactNativeBundleCommand(this.bundleName, this.development, this.entryFile, this.updateContentsPath, this.os, this.sourcemapOutput, this.extraBundlerOptions);
-
+      // Check if we have to run hermes to compile JS to Byte Code if Hermes is enabled in build.gradle and we're releasing an Android build
+      if (this.os === "android") {
+        const isHermesEnabled = await getHermesEnabled(this.gradleFile);
+        if (isHermesEnabled) {
+          await runHermesEmitBinaryCommand(this.bundleName, this.updateContentsPath, this.sourcemapOutput, this.extraHermesFlags);
+        }
+      }
       out.text(chalk.cyan("\nReleasing update contents to CodePush:\n"));
 
       return await this.release(client);


### PR DESCRIPTION
This is a respond PR to the request in React Native Code Push repository:

https://github.com/microsoft/react-native-code-push/issues/1626

This will enable CodePush to support the latest JS to Byte Code engine, the Hermes from Facebook to boost up Android's performance.

It will check if Hermes is enabled in the `android/app/build.gradle`, and invoke Hermes to compile the JS bundle to a byte code bundle, replace the original JS bundle with the newly created byte code bundle, and finally, upload the byte code bundle to App Center.

For a further explanation, a Hermes enabled Android build is capable to execute both JS and Hermes byte code bundle, hence we don't have to modify any code in the client side(react-native-code-push).

Screenshot:
<img width="718" alt="Screen Shot 2019-08-06 at 4 27 55 PM" src="https://user-images.githubusercontent.com/182688/62523914-53e26900-b867-11e9-88ee-0040313ac80b.png">

<img width="1352" alt="Screen Shot 2019-08-06 at 4 34 58 PM" src="https://user-images.githubusercontent.com/182688/62524543-6610d700-b868-11e9-8492-51296785d859.png">
