### PR TITLE
Prefer hermes-engine over hermesvm

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -271,8 +271,9 @@ export function runHermesEmitBinaryCommand(bundleName: string, outputFolder: str
   }
 
   out.text(chalk.cyan("Converting JS bundle to byte code via Hermes, running command:\n"));
-  const hermesProcess = spawn(path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes"), hermesArgs);
-  out.text(`${path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes")} ${hermesArgs.join(" ")}`);
+  const hermesCommand = getHermesCommand();
+  const hermesProcess = spawn(hermesCommand, hermesArgs);
+  out.text(`${hermesCommand} ${hermesArgs.join(" ")}`);
 
   return new Promise<void>((resolve, reject) => {
       hermesProcess.stdout.on("data", (data: Buffer) => {
@@ -343,6 +344,18 @@ function getHermesOSBin(): string {
     default:
       return "linux64-bin";
   }
+}
+
+function getHermesCommand(): string {
+  const fileExists = (file: string): boolean => {
+    try { return fs.statSync(file).isFile(); } catch (e) { return false; }
+  };
+  // assume if hermes-engine exists it should be used instead of hermesvm
+  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), "hermes");
+  if (fileExists(hermesEngine)) {
+    return hermesEngine;
+  }
+  return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
 }
 
 export function isValidOS(os: string): boolean {


### PR DESCRIPTION
If hermes-engine is installed in node_modules, prefer the hermes binary
from there vs the one in hermesvm.

Ideally the `hermesCommand` could be parsed and used from the build.gradle
but parsing the gradle-to-js output for `hermesCommand` is not trivial. I think the
heuristic of preferring `hermes-engine` over `hermesvm` should be correct in the
vast majority of cases.

I've tested this locally with `ts-node` on a react-native 0.60.x project for the case when both `hermes-engine` and `hermesvm` are installed and when only `hermesvm` is installed.

Closes #653 