### PR TITLE
Add aliases for publishing to stores and groups

### DIFF
--- a/src/commands/distribute/groups/publish.ts
+++ b/src/commands/distribute/groups/publish.ts
@@ -1,0 +1,64 @@
+import { isNil } from "lodash";
+import { AppCenterClient } from "../../../util/apis";
+import { AppCommand, CommandArgs, CommandResult, hasArg, help, longName, required, shortName } from "../../../util/commandline";
+import ReleaseBinaryCommand from "../release";
+
+const debug = require("debug")("appcenter-cli:commands:distribute:groups:publish");
+
+@help("Publish an app file to a group")
+export default class PublishToGroupCommand extends AppCommand {
+  @help("Path to binary file")
+  @shortName("f")
+  @longName("file")
+  @required
+  @hasArg
+  public filePath: string;
+
+  @help("Build version parameter required for .zip and .msi files")
+  @shortName("b")
+  @longName("build-version")
+  @hasArg
+  public buildVersion: string;
+
+  @help("Distribution group name")
+  @shortName("g")
+  @longName("group")
+  @hasArg
+  @required
+  public distributionGroup: string;
+
+  @help("Release notes text")
+  @shortName("r")
+  @longName("release-notes")
+  @hasArg
+  public releaseNotes: string;
+
+  @help("Path to release notes file")
+  @shortName("R")
+  @longName("release-notes-file")
+  @hasArg
+  public releaseNotesFile: string;
+
+  public async run(client: AppCenterClient): Promise<CommandResult> {
+    const releaseArgs = ["--app", this.app.identifier, "--file", this.filePath, "--group", this.distributionGroup];
+    if (!isNil(this.buildVersion)) {
+      releaseArgs.push("--build-version", this.buildVersion);
+    }
+    if (!isNil(this.releaseNotes)) {
+      releaseArgs.push("--release-notes", this.releaseNotes);
+    }
+    if (!isNil(this.releaseNotesFile)) {
+      releaseArgs.push("--release-notes-file", this.releaseNotesFile);
+    }
+
+    const releaseCommandArgs: CommandArgs = {
+      args: releaseArgs,
+      command: ["distribute", "release"],
+      commandPath: undefined
+    };
+
+    debug("Forwarding to distribute release command");
+    const releaseCommand = new ReleaseBinaryCommand(releaseCommandArgs);
+    return releaseCommand.run(client);
+  }
+}

--- a/src/commands/distribute/stores/publish.ts
+++ b/src/commands/distribute/stores/publish.ts
@@ -1,0 +1,64 @@
+import { isNil } from "lodash";
+import { AppCenterClient } from "../../../util/apis";
+import { AppCommand, CommandArgs, CommandResult, hasArg, help, longName, required, shortName } from "../../../util/commandline";
+import ReleaseBinaryCommand from "../release";
+
+const debug = require("debug")("appcenter-cli:commands:distribute:stores:publish");
+
+@help("Publish an app file to a store")
+export default class PublishToStoreCommand extends AppCommand {
+  @help("Path to binary file")
+  @shortName("f")
+  @longName("file")
+  @required
+  @hasArg
+  public filePath: string;
+
+  @help("Build version parameter required for .zip and .msi files")
+  @shortName("b")
+  @longName("build-version")
+  @hasArg
+  public buildVersion: string;
+
+  @help("Store name")
+  @shortName("s")
+  @longName("store")
+  @hasArg
+  @required
+  public storeName: string;
+
+  @help("Release notes text")
+  @shortName("r")
+  @longName("release-notes")
+  @hasArg
+  public releaseNotes: string;
+
+  @help("Path to release notes file")
+  @shortName("R")
+  @longName("release-notes-file")
+  @hasArg
+  public releaseNotesFile: string;
+
+  public async run(client: AppCenterClient): Promise<CommandResult> {
+    const releaseArgs = ["--app", this.app.identifier, "--file", this.filePath, "--store", this.storeName];
+    if (!isNil(this.buildVersion)) {
+      releaseArgs.push("--build-version", this.buildVersion);
+    }
+    if (!isNil(this.releaseNotes)) {
+      releaseArgs.push("--release-notes", this.releaseNotes);
+    }
+    if (!isNil(this.releaseNotesFile)) {
+      releaseArgs.push("--release-notes-file", this.releaseNotesFile);
+    }
+
+    const releaseCommandArgs: CommandArgs = {
+      args: releaseArgs,
+      command: ["distribute", "release"],
+      commandPath: undefined
+    };
+
+    debug("Forwarding to distribute release command");
+    const releaseCommand = new ReleaseBinaryCommand(releaseCommandArgs);
+    return releaseCommand.run(client);
+  }
+}

--- a/test/commands/distribute/fakes.ts
+++ b/test/commands/distribute/fakes.ts
@@ -1,0 +1,33 @@
+import { AppCenterClient } from "../../../src/util/apis";
+import { AppCommand, CommandResult, hasArg, longName, shortName } from "../../../src/util/commandline";
+
+export class FakeReleaseBinaryCommand extends AppCommand {
+  @shortName("f")
+  @longName("file")
+  @hasArg
+  public filePath: string;
+  @shortName("b")
+  @longName("build-version")
+  @hasArg
+  public buildVersion: string;
+  @shortName("g")
+  @longName("group")
+  @hasArg
+  public distributionGroup: string;
+  @shortName("s")
+  @longName("store")
+  @hasArg
+  public storeName: string;
+  @shortName("r")
+  @longName("release-notes")
+  @hasArg
+  public releaseNotes: string;
+  @shortName("R")
+  @longName("release-notes-file")
+  @hasArg
+  public releaseNotesFile: string;
+
+  public async run(client: AppCenterClient) : Promise<CommandResult> {
+    return null;
+  }
+}

--- a/test/commands/distribute/groups/publish-test.ts
+++ b/test/commands/distribute/groups/publish-test.ts
@@ -1,0 +1,95 @@
+import { expect } from "chai";
+import * as Nock from "nock";
+import * as Sinon from "sinon";
+
+import PublishToGroupCommand from "../../../../src/commands/distribute/groups/publish";
+import ReleaseBinaryCommand from "../../../../src/commands/distribute/release";
+import { CommandArgs, CommandFailedResult, isCommandFailedResult, notFound } from "../../../../src/util/commandline";
+import { FakeReleaseBinaryCommand } from "../fakes";
+
+describe("distribute groups publish command", () => {
+  const fakeAppOwner = "fakeAppOwner";
+  const fakeAppName = "fakeAppName";
+  const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;
+  const fakeToken = "c1o3d3e7";
+  const fakeFilePath = "/fake/file.ipa";
+  const fakeGroupName = "myFakeGroup";
+  const releaseNotes = "Fake release";
+  const fakeReleaseNotesFile = "/fake/release_notes";
+  const buildVersion = "123";
+  const fakeCommandPath = "fake/distribute/groups/publish.ts";
+  const expectedReleaseCommandPath = "fake/distribute/release.ts";
+  const originalReleaseBinaryCommandPrototype = Object.getPrototypeOf(ReleaseBinaryCommand);
+
+  let sandbox: Sinon.SinonSandbox;
+  let createReleaseStub: Sinon.SinonStub;
+  let runReleaseStub: Sinon.SinonStub;
+
+  before(() => {
+    sandbox = Sinon.createSandbox();
+
+    // Just to be safe
+    Nock.disableNetConnect();
+  });
+
+  beforeEach(() => {
+    runReleaseStub = sandbox.stub(FakeReleaseBinaryCommand.prototype, "run");
+    runReleaseStub.returns(notFound("42"));
+    createReleaseStub = sandbox.stub().callsFake((args) => { return new FakeReleaseBinaryCommand(args); });
+    Object.setPrototypeOf(ReleaseBinaryCommand, createReleaseStub);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    Object.setPrototypeOf(ReleaseBinaryCommand, originalReleaseBinaryCommandPrototype);
+  });
+
+  after(() => {
+    Nock.enableNetConnect();
+  });
+
+  it("passes all non-common parameters to distribute release", async () => {
+    const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes, "-R", fakeReleaseNotesFile]));
+    await command.execute();
+
+    // Make sure it created a ReleaseBinaryCommand and ran it
+    Sinon.assert.calledOnce(createReleaseStub);
+    Sinon.assert.calledOnce(runReleaseStub);
+
+    // Make sure it provided the correct path
+    const createArgs: CommandArgs = createReleaseStub.args[0][0] as CommandArgs;
+    expect(createArgs.commandPath).to.equal(expectedReleaseCommandPath);
+
+    // Make sure all parameters were passed correctly to the aliased command, including the illegal combination of -r and -R
+    const releaseCommand: FakeReleaseBinaryCommand = createReleaseStub.returnValues[0];
+    expect(releaseCommand.app.identifier).equals(fakeAppIdentifier);
+    expect(releaseCommand.filePath).equals(fakeFilePath);
+    expect(releaseCommand.buildVersion).equals(buildVersion);
+    expect(releaseCommand.distributionGroup).equals(fakeGroupName);
+    expect(releaseCommand.storeName).to.be.undefined;
+    expect(releaseCommand.releaseNotes).equals(releaseNotes);
+    expect(releaseCommand.releaseNotesFile).equals(fakeReleaseNotesFile);
+  });
+
+  it("returns the return value of 'distribute release'", async () => {
+    const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes]));
+    const result = await command.execute();
+
+    expect(isCommandFailedResult(result)).to.be.true;
+    expect((result as CommandFailedResult).errorMessage).to.equal("Command 42 not found");
+  });
+
+  function getCommandArgs(additionalArgs: string[]): CommandArgs {
+    const args: string[] = [
+      "-a", fakeAppIdentifier,
+      "-f", fakeFilePath,
+      "-g", fakeGroupName,
+      "--token", fakeToken,
+      "--env", "local"].concat(additionalArgs);
+    return {
+      args,
+      command: ["distribute", "groups", "publish"],
+      commandPath: fakeCommandPath
+    };
+  }
+});

--- a/test/commands/distribute/groups/publish-test.ts
+++ b/test/commands/distribute/groups/publish-test.ts
@@ -18,7 +18,6 @@ describe("distribute groups publish command", () => {
   const fakeReleaseNotesFile = "/fake/release_notes";
   const buildVersion = "123";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
-  const expectedReleaseCommandPath = "fake/distribute/release.ts";
   const originalReleaseBinaryCommandPrototype = Object.getPrototypeOf(ReleaseBinaryCommand);
 
   let sandbox: Sinon.SinonSandbox;
@@ -55,10 +54,6 @@ describe("distribute groups publish command", () => {
     // Make sure it created a ReleaseBinaryCommand and ran it
     Sinon.assert.calledOnce(createReleaseStub);
     Sinon.assert.calledOnce(runReleaseStub);
-
-    // Make sure it provided the correct path
-    const createArgs: CommandArgs = createReleaseStub.args[0][0] as CommandArgs;
-    expect(createArgs.commandPath).to.equal(expectedReleaseCommandPath);
 
     // Make sure all parameters were passed correctly to the aliased command, including the illegal combination of -r and -R
     const releaseCommand: FakeReleaseBinaryCommand = createReleaseStub.returnValues[0];

--- a/test/commands/distribute/stores/publish-test.ts
+++ b/test/commands/distribute/stores/publish-test.ts
@@ -18,7 +18,6 @@ describe("distribute stores publish command", () => {
   const fakeReleaseNotesFile = "/fake/release_notes";
   const buildVersion = "123";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
-  const expectedReleaseCommandPath = "fake/distribute/release.ts";
 
   let sandbox: Sinon.SinonSandbox;
   let createReleaseStub: Sinon.SinonStub;
@@ -53,10 +52,6 @@ describe("distribute stores publish command", () => {
     // Make sure it created a ReleaseBinaryCommand and ran it
     Sinon.assert.calledOnce(createReleaseStub);
     Sinon.assert.calledOnce(runReleaseStub);
-
-    // Make sure it provided the correct path
-    const createArgs: CommandArgs = createReleaseStub.args[0][0] as CommandArgs;
-    expect(createArgs.commandPath).to.equal(expectedReleaseCommandPath);
 
     // Make sure all parameters were passed correctly to the aliased command, including the illegal combination of -r and -R
     const releaseCommand: FakeReleaseBinaryCommand = createReleaseStub.returnValues[0];

--- a/test/commands/distribute/stores/publish-test.ts
+++ b/test/commands/distribute/stores/publish-test.ts
@@ -1,0 +1,93 @@
+import * as Sinon from "sinon";
+import * as Nock from "nock";
+import { expect } from "chai";
+
+import { CommandArgs, CommandFailedResult, isCommandFailedResult, notFound } from "../../../../src/util/commandline";
+import PublishToStoreCommand from "../../../../src/commands/distribute/stores/publish";
+import ReleaseBinaryCommand from "../../../../src/commands/distribute/release";
+import { FakeReleaseBinaryCommand } from "../fakes";
+
+describe("distribute stores publish command", () => {
+  const fakeAppOwner = "fakeAppOwner";
+  const fakeAppName = "fakeAppName";
+  const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;
+  const fakeToken = "c1o3d3e7";
+  const fakeFilePath = "/fake/file.ipa";
+  const fakeStoreName = "myFakeStore";
+  const releaseNotes = "Fake release";
+  const fakeReleaseNotesFile = "/fake/release_notes";
+  const buildVersion = "123";
+  const fakeCommandPath = "fake/distribute/groups/publish.ts";
+  const expectedReleaseCommandPath = "fake/distribute/release.ts";
+
+  let sandbox: Sinon.SinonSandbox;
+  let createReleaseStub: Sinon.SinonStub;
+  let runReleaseStub: Sinon.SinonStub;
+
+  before(() => {
+    sandbox = Sinon.createSandbox();
+
+    // Just to be safe
+    Nock.disableNetConnect();
+  });
+
+  beforeEach(() => {
+    runReleaseStub = sandbox.stub(FakeReleaseBinaryCommand.prototype, "run");
+    runReleaseStub.returns(notFound("42"));
+    createReleaseStub = sandbox.stub().callsFake((args) => { return new FakeReleaseBinaryCommand(args); });
+    Object.setPrototypeOf(ReleaseBinaryCommand, createReleaseStub);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  after(() => {
+    Nock.enableNetConnect();
+  });
+
+  it("passes all non-common parameters to distribute release", async () => {
+    const command = new PublishToStoreCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes, "-R", fakeReleaseNotesFile]));
+    await command.execute();
+
+    // Make sure it created a ReleaseBinaryCommand and ran it
+    Sinon.assert.calledOnce(createReleaseStub);
+    Sinon.assert.calledOnce(runReleaseStub);
+
+    // Make sure it provided the correct path
+    const createArgs: CommandArgs = createReleaseStub.args[0][0] as CommandArgs;
+    expect(createArgs.commandPath).to.equal(expectedReleaseCommandPath);
+
+    // Make sure all parameters were passed correctly to the aliased command, including the illegal combination of -r and -R
+    const releaseCommand: FakeReleaseBinaryCommand = createReleaseStub.returnValues[0];
+    expect(releaseCommand.app.identifier).equals(fakeAppIdentifier);
+    expect(releaseCommand.filePath).equals(fakeFilePath);
+    expect(releaseCommand.buildVersion).equals(buildVersion);
+    expect(releaseCommand.distributionGroup).to.be.undefined;
+    expect(releaseCommand.storeName).equals(fakeStoreName);
+    expect(releaseCommand.releaseNotes).equals(releaseNotes);
+    expect(releaseCommand.releaseNotesFile).equals(fakeReleaseNotesFile);
+  });
+
+  it("returns the return value of 'distribute release'", async () => {
+    const command = new PublishToStoreCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes]));
+    const result = await command.execute();
+
+    expect(isCommandFailedResult(result)).to.be.true;
+    expect((result as CommandFailedResult).errorMessage).to.equal("Command 42 not found");
+  });
+
+  function getCommandArgs(additionalArgs: string[]): CommandArgs {
+    const args: string[] = [
+      "-a", fakeAppIdentifier,
+      "-f", fakeFilePath,
+      "-s", fakeStoreName,
+      "--token", fakeToken,
+      "--env", "local"].concat(additionalArgs);
+    return {
+      args,
+      command: ["distribute", "stores", "publish"],
+      commandPath: fakeCommandPath
+    };
+  }
+});


### PR DESCRIPTION
Add two new commands:

- `distribute stores publish` which performs the same actions as `distribute release --store`.
- `distribute groups publish` which performs the same actions as `distribute release --group`.