### PR TITLE
Fix "npm pack" usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/obj
 src/commands/test/lib/templates/uitest/ios/.vs
 src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/bin
 src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/obj
+
+# Package
+/appcenter-cli-*.tgz
+

--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,7 @@ tools
 
 # Users Environment Variables
 .lock-wscript
+
+# Package
+/appcenter-cli-*.tgz
+

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "bugs": {
     "url": "https://github.com/Microsoft/appcenter-cli/issues"
   },
+  "files": [
+    "package-lock.json",
+    "bin",
+    "dist"
+  ],
   "devDependencies": {
     "@types/async": "^3.0.2",
     "@types/chai": "^4.2.3",


### PR DESCRIPTION
`npm pack` can be used to generate a smaller package, that we can then publish on GitHub. The rules in this PR select only the files in `bin/` and `dist/` for installation.