### PR TITLE
Require release notes for store publishing to an Apple store track

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -148,7 +148,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
 
   private validateParametersWithPrerequisites(storeInformation: models.ExternalStoreResponse): void {
     debug("Checking for invalid parameter combinations with prerequisites");
-    if (!_.isNil(this.storeName) && storeInformation.type === "apple" && _.isNil(this.releaseNotes) && _.isNil(this.releaseNotesFile)) {
+    if (storeInformation && storeInformation.type === "apple" && _.isNil(this.releaseNotes) && _.isNil(this.releaseNotesFile)) {
       throw failure(ErrorCodes.InvalidParameter, "At least one of '--release-notes' or '--release-notes-file' must be specified when publishing to an Apple store.");
     }
   }

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -13,7 +13,7 @@ import { CommandArgs, CommandResult, CommandFailedResult } from "../../../../src
 
 Temp.track();
 
-describe.only("release command", () => {
+describe("release command", () => {
   const fakeAppOwner = "fakeAppOwner";
   const fakeAppName = "fakeAppName";
   const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -13,7 +13,7 @@ import { CommandArgs, CommandResult, CommandFailedResult } from "../../../../src
 
 Temp.track();
 
-describe("release command", () => {
+describe.only("release command", () => {
   const fakeAppOwner = "fakeAppOwner";
   const fakeAppName = "fakeAppName";
   const fakeAppIdentifier = `${fakeAppOwner}/${fakeAppName}`;
@@ -146,6 +146,19 @@ describe("release command", () => {
       testUploadedFormData();
     });
 
+    it("uploads release with neither release notes nor file to Google Play Store", async () => {
+      // Arrange
+      const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
+
+      // Act
+      const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-s", fakeStoreName]));
+      const result = await command.execute();
+      console.log(result);
+
+      // Assert
+      testCommandSuccess(result, expectedRequestsScope, skippedRequestsScope);
+      testUploadedFormData();
+    });
   });
 
   context("build-version", () => {
@@ -440,6 +453,33 @@ describe("release command", () => {
       const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-R", releaseNotesFilePath]));
       await expect(command.execute()).to.eventually.be.rejected;
     });
+
+    describe("when publishing to an 'apple' type store", () => {
+      beforeEach(() => {
+          expectedRequestsScope =
+            setupSuccessfulGetStoreDetailsResponse(
+              setupSuccessfulPostUploadResponse(
+                setupSuccessfulUploadResponse(
+                  setupSuccessfulPatchUploadResponse(
+                    setupSuccessfulCreateReleaseResponse(
+                      setupSuccessfulAddStoreResponse(
+                        Nock(fakeHost)))))),
+              "apple");
+          skippedRequestsScope = setupSuccessfulAbortUploadResponse(Nock(fakeHost));
+      });
+
+      it("fails if neither --release-notes nor --release-notes-file is specified", async () => {
+        // Arrange
+        const expectedErrorMessage = "At least one of '--release-notes' or '--release-notes-file' must be specified when publishing to an Apple store.";
+
+        // Act
+        const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-s", fakeStoreName]));
+        const result = await expect(command.execute()).to.eventually.be.rejected as CommandFailedResult;
+
+        // Assert
+        testFailure(result, expectedErrorMessage, skippedRequestsScope);
+      });
+    });
   });
 
   afterEach(() => {
@@ -572,14 +612,14 @@ describe("release command", () => {
     });
   }
 
-  function setupSuccessfulGetStoreDetailsResponse(nockScope: Nock.Scope): Nock.Scope {
+  function setupSuccessfulGetStoreDetailsResponse(nockScope: Nock.Scope, storeType: string = fakeStoreType): Nock.Scope {
     const getDistributionStoresUrl = `/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_stores/${fakeStoreName}`;
 
     return nockScope.get(getDistributionStoresUrl)
     .reply(200, {
       id: fakeStoreId,
       name: fakeStoreName,
-      type: fakeStoreType,
+      type: storeType,
       track: fakeStoreTrack
     });
   }

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -115,7 +115,8 @@ describe.only("release command", () => {
                 setupSuccessfulPatchUploadResponse(
                   setupSuccessfulCreateReleaseResponse(
                     setupSuccessfulAddStoreResponse(
-                      Nock(fakeHost)))))));
+                      Nock(fakeHost))
+                  , false)))));
         skippedRequestsScope = setupSuccessfulAbortUploadResponse(Nock(fakeHost));
     });
 
@@ -456,16 +457,7 @@ describe.only("release command", () => {
 
     describe("when publishing to an 'apple' type store", () => {
       beforeEach(() => {
-          expectedRequestsScope =
-            setupSuccessfulGetStoreDetailsResponse(
-              setupSuccessfulPostUploadResponse(
-                setupSuccessfulUploadResponse(
-                  setupSuccessfulPatchUploadResponse(
-                    setupSuccessfulCreateReleaseResponse(
-                      setupSuccessfulAddStoreResponse(
-                        Nock(fakeHost)))))),
-              "apple");
-          skippedRequestsScope = setupSuccessfulAbortUploadResponse(Nock(fakeHost));
+          expectedRequestsScope = setupSuccessfulGetStoreDetailsResponse(Nock(fakeHost), "apple");
       });
 
       it("fails if neither --release-notes nor --release-notes-file is specified", async () => {
@@ -477,7 +469,7 @@ describe.only("release command", () => {
         const result = await expect(command.execute()).to.eventually.be.rejected as CommandFailedResult;
 
         // Assert
-        testFailure(result, expectedErrorMessage, skippedRequestsScope);
+        testFailure(result, expectedErrorMessage, expectedRequestsScope);
       });
     });
   });


### PR DESCRIPTION
When running publishing a release to an Apple store track using `distribute release --store` or `distribute stores publish` with neither `-r` nor `-R` specified, an early failure warns of the required release notes. Release notes are not required for publishing to other types of stores.