### PR TITLE
release: Add extension filter for store/group

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -138,9 +138,18 @@ export default class ReleaseBinaryCommand extends AppCommand {
     if (_.isNil(this.distributionGroup) && _.isNil(this.storeName)) {
       throw failure(ErrorCodes.InvalidParameter, "At least one of '--group' or '--store' must be specified");
     }
+    if (!_.isNil(this.distributionGroup)) {
+      if ([".aab"].includes(this.fileExtension)) {
+        throw failure(ErrorCodes.InvalidParameter, `Files of type '${this.fileExtension}' can not be distributed to groups`);
+      }
+    }
+    if (!_.isNil(this.storeName)) {
+      if (![".aab", ".apk", ".ipa"].includes(this.fileExtension)) {
+        throw failure(ErrorCodes.InvalidParameter, `Files of type '${this.fileExtension}' can not be distributed to stores`);
+      }
+    }
     if (_.isNil(this.buildVersion)) {
-      const extension = this.filePath.substring(this.filePath.lastIndexOf(".")).toLowerCase();
-      if ([".zip", ".msi"].includes(extension)) {
+      if ([".zip", ".msi"].includes(this.fileExtension)) {
         throw failure(ErrorCodes.InvalidParameter, "--build-version parameter must be specified when uploading .zip or .msi file");
       }
     }
@@ -377,5 +386,9 @@ export default class ReleaseBinaryCommand extends AppCommand {
       debug(`Failed to distribute the release to store - ${inspect(error)}`);
       throw failure(ErrorCodes.Exception, error.message);
     }
+  }
+
+  private get fileExtension(): string {
+    return Path.parse(this.filePath).ext.toLowerCase();
   }
 }

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -33,8 +33,8 @@ describe("release command", () => {
   const version = "1.0";
   const shortVersion = "1";
 
-  const releaseFileName = "releaseBinaryFile";
-  const releaseNotesFileName = "releaseNotesFile";
+  const releaseFileName = "releaseBinaryFile.apk";
+  const releaseNotesFileName = "releaseNotesFile.txt";
 
   const releaseFileContent = "Hello World!";
 
@@ -452,6 +452,16 @@ describe("release command", () => {
 
     it("fails if neither --group nor --store is specified", async () => {
       const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-R", releaseNotesFilePath]));
+      await expect(command.execute()).to.eventually.be.rejected;
+    });
+
+    it("fails if distributing invalid file type to store", async () => {
+      const command = new ReleaseBinaryCommand(getCommandArgs(["-f", "invalid.ext", "-R", releaseNotesFilePath, "--store", fakeStoreName]));
+      await expect(command.execute()).to.eventually.be.rejected;
+    });
+
+    it("fails if distributing invalid file type to group", async () => {
+      const command = new ReleaseBinaryCommand(getCommandArgs(["-f", "invalid.aab", "-R", releaseNotesFilePath, "--group", fakeStoreName]));
       await expect(command.execute()).to.eventually.be.rejected;
     });
 

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -235,6 +235,21 @@ describe("release command", () => {
         // Assert
         testFailure(result, expectedErrorMessage, skippedRequestsScope);
       });
+
+      it("passes with aab for stores", async () => {
+        const command = new ReleaseBinaryCommand(getCommandArgs(["-f", "valid.aab", "-r", "release notes", "--store", fakeStoreName]));
+        await expect(command.execute()).to.eventually.be.rejected;
+      });
+
+      it("passes with apk for stores", async () => {
+        const command = new ReleaseBinaryCommand(getCommandArgs(["-f", "valid.apk", "-r", "release notes", "--store", fakeStoreName]));
+        await expect(command.execute()).to.eventually.be.rejected;
+      });
+
+      it("passes with ipa for stores", async () => {
+        const command = new ReleaseBinaryCommand(getCommandArgs(["-f", "valid.ipa", "-r", "release notes", "--store", fakeStoreName]));
+        await expect(command.execute()).to.eventually.be.rejected;
+      });
     });
 
   });


### PR DESCRIPTION
This should fail early without creating a release on App Center
for the most common cases, and the least likely to change on
App Center side.