### PR TITLE
release: Skip empty release notes

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -91,8 +91,12 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Extracting release ID from the release URL");
     const releaseId = this.extractReleaseId(releaseUrl);
 
-    debug("Setting release notes");
-    await this.putReleaseDetails(client, app, releaseId, releaseNotesString);
+    if (releaseNotesString && releaseNotesString.length > 0) {
+      debug("Setting release notes");
+      await this.putReleaseDetails(client, app, releaseId, releaseNotesString);
+    } else {
+      debug("Skipping empty release notes");
+    }
 
     if (!_.isNil(this.distributionGroup)) {
       debug("Distributing the release to a group");
@@ -349,6 +353,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
 
       const statusCode = response.statusCode;
       if (statusCode >= 400) {
+        debug(`Got error response: ${inspect(response)}`);
         throw statusCode;
       }
       return result;

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -359,10 +359,10 @@ export default class ReleaseBinaryCommand extends AppCommand {
       return result;
     } catch (error) {
       if (error === 400) {
-        throw failure(ErrorCodes.Exception, "changing distribution group is not supported");
+        throw failure(ErrorCodes.Exception, "failed to set the release notes");
       } else {
         debug(`Failed to distribute the release - ${inspect(error)}`);
-        throw failure(ErrorCodes.Exception, `failed to set distribution group for release ${releaseId}`);
+        throw failure(ErrorCodes.Exception, `failed to set release notes for release ${releaseId}`);
       }
     }
   }

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -146,7 +146,19 @@ describe("release command", () => {
       testCommandSuccess(result, expectedRequestsScope, skippedRequestsScope);
       testUploadedFormData();
     });
+  });
 
+  describe("when all network requests are successful (no release notes)", () => {
+    beforeEach(() => {
+        expectedRequestsScope =
+          setupSuccessfulGetStoreDetailsResponse(
+            setupSuccessfulPostUploadResponse(
+              setupSuccessfulUploadResponse(
+                setupSuccessfulPatchUploadResponse(
+                  setupSuccessfulAddStoreResponse(
+                    Nock(fakeHost))))));
+        skippedRequestsScope = setupSuccessfulAbortUploadResponse(Nock(fakeHost));
+    });
     it("uploads release with neither release notes nor file to Google Play Store", async () => {
       // Arrange
       const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
@@ -154,7 +166,6 @@ describe("release command", () => {
       // Act
       const command = new ReleaseBinaryCommand(getCommandArgs(["-f", releaseFilePath, "-s", fakeStoreName]));
       const result = await command.execute();
-      console.log(result);
 
       // Assert
       testCommandSuccess(result, expectedRequestsScope, skippedRequestsScope);
@@ -173,10 +184,9 @@ describe("release command", () => {
           setupSuccessfulPostUploadResponse(
             setupSuccessfulUploadResponse(
               setupSuccessfulPatchUploadResponse(
-                setupSuccessfulCreateReleaseResponse(
-                  setupSuccessfulAddGroupResponse(
-                    setupSuccsessFulGetDistributionGroupResponse(
-                      Nock(fakeHost))), false)))));
+                setupSuccessfulAddGroupResponse(
+                  setupSuccsessFulGetDistributionGroupResponse(
+                    Nock(fakeHost)))))));
         skippedRequestsScope = setupSuccessfulAbortUploadResponse(Nock(fakeHost));
       });
 
@@ -375,7 +385,7 @@ describe("release command", () => {
         setupSuccessfulAddGroupResponse(Nock(fakeHost)));
     });
 
-    it("does not try to add the group to the release", async () => {
+    it("does not try to set the release notes for the release", async () => {
       // Arrange
       const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
       const releaseNotesFilePath = createFile(tmpFolderPath, releaseNotesFileName, releaseNotes);
@@ -385,7 +395,7 @@ describe("release command", () => {
       const result = await expect(command.execute()).to.eventually.be.rejected as CommandFailedResult;
 
       // Assert
-      testFailure(result, `failed to set distribution group for release ${fakeReleaseId}`, expectedRequestsScope, skippedRequestsScope);
+      testFailure(result, `failed to set release notes for release ${fakeReleaseId}`, expectedRequestsScope, skippedRequestsScope);
     });
   });
 


### PR DESCRIPTION
This is allowed for Google Play and distribution groups.
This check avoids getting a 400 error which was then badly
translated as:
  "changing distribution group is not supported"