### PR TITLE
Fix build version/number for "publish" ops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,7 +532,7 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "optional": true
@@ -665,7 +665,7 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "optional": true
@@ -678,7 +678,7 @@
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "optional": true,
@@ -1317,7 +1317,7 @@
     },
     "chownr": {
       "version": "1.1.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true,
       "optional": true
@@ -1618,7 +1618,7 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "optional": true
@@ -1877,7 +1877,7 @@
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "optional": true
@@ -1889,7 +1889,7 @@
     },
     "detect-libc": {
       "version": "1.0.3",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "optional": true
@@ -2520,7 +2520,7 @@
     },
     "fs-minipass": {
       "version": "1.2.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "optional": true,
@@ -2604,12 +2604,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2617,22 +2617,22 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2646,7 +2646,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "requires": {
             "glob": "^7.1.3"
@@ -2654,22 +2654,22 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2677,7 +2677,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2685,7 +2685,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
@@ -2708,7 +2708,7 @@
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "optional": true,
@@ -3434,7 +3434,7 @@
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "optional": true
@@ -3527,7 +3527,7 @@
     },
     "ignore-walk": {
       "version": "3.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "optional": true,
@@ -4484,7 +4484,7 @@
     },
     "minipass": {
       "version": "2.3.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "optional": true,
@@ -4504,7 +4504,7 @@
     },
     "minizlib": {
       "version": "1.2.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "optional": true,
@@ -4743,7 +4743,7 @@
     },
     "needle": {
       "version": "2.3.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
       "dev": true,
       "optional": true,
@@ -4831,7 +4831,7 @@
     },
     "node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "dev": true,
       "optional": true,
@@ -4859,7 +4859,7 @@
     },
     "nopt": {
       "version": "4.0.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "optional": true,
@@ -4913,14 +4913,14 @@
     },
     "npm-bundled": {
       "version": "1.0.6",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "dev": true,
       "optional": true
     },
     "npm-packlist": {
       "version": "1.4.1",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "dev": true,
       "optional": true,
@@ -4939,7 +4939,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "optional": true,
@@ -5109,7 +5109,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "optional": true
@@ -5172,7 +5172,7 @@
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "optional": true,
@@ -6473,7 +6473,7 @@
     },
     "tar": {
       "version": "4.4.8",
-      "resolved": false,
+      "resolved": "",
       "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "optional": true,

--- a/src/commands/distribute/groups/publish.ts
+++ b/src/commands/distribute/groups/publish.ts
@@ -14,11 +14,17 @@ export default class PublishToGroupCommand extends AppCommand {
   @hasArg
   public filePath: string;
 
-  @help("Build version parameter required for .zip and .msi files")
+  @help("Build version parameter required for .zip, .msi, .pkg and .dmg files")
   @shortName("b")
   @longName("build-version")
   @hasArg
   public buildVersion: string;
+
+  @help("Build number parameter required for macOS .pkg and .dmg files")
+  @shortName("n")
+  @longName("build-number")
+  @hasArg
+  public buildNumber: string;
 
   @help("Distribution group name")
   @shortName("g")
@@ -43,6 +49,9 @@ export default class PublishToGroupCommand extends AppCommand {
     const releaseArgs = ["--app", this.app.identifier, "--file", this.filePath, "--group", this.distributionGroup];
     if (!isNil(this.buildVersion)) {
       releaseArgs.push("--build-version", this.buildVersion);
+    }
+    if (!isNil(this.buildNumber)) {
+      releaseArgs.push("--build-number", this.buildNumber);
     }
     if (!isNil(this.releaseNotes)) {
       releaseArgs.push("--release-notes", this.releaseNotes);

--- a/src/commands/distribute/stores/publish.ts
+++ b/src/commands/distribute/stores/publish.ts
@@ -14,12 +14,6 @@ export default class PublishToStoreCommand extends AppCommand {
   @hasArg
   public filePath: string;
 
-  @help("Build version parameter required for .zip and .msi files")
-  @shortName("b")
-  @longName("build-version")
-  @hasArg
-  public buildVersion: string;
-
   @help("Store name")
   @shortName("s")
   @longName("store")
@@ -41,9 +35,6 @@ export default class PublishToStoreCommand extends AppCommand {
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const releaseArgs = ["--app", this.app.identifier, "--file", this.filePath, "--store", this.storeName];
-    if (!isNil(this.buildVersion)) {
-      releaseArgs.push("--build-version", this.buildVersion);
-    }
     if (!isNil(this.releaseNotes)) {
       releaseArgs.push("--release-notes", this.releaseNotes);
     }

--- a/test/commands/distribute/fakes.ts
+++ b/test/commands/distribute/fakes.ts
@@ -6,25 +6,36 @@ export class FakeReleaseBinaryCommand extends AppCommand {
   @longName("file")
   @hasArg
   public filePath: string;
+
   @shortName("b")
   @longName("build-version")
   @hasArg
   public buildVersion: string;
+
+  @shortName("n")
+  @longName("build-number")
+  @hasArg
+  public buildNumber: string;
+
   @shortName("g")
   @longName("group")
   @hasArg
   public distributionGroup: string;
+
   @shortName("s")
   @longName("store")
   @hasArg
   public storeName: string;
+
   @shortName("r")
   @longName("release-notes")
   @hasArg
+
   public releaseNotes: string;
   @shortName("R")
   @longName("release-notes-file")
   @hasArg
+
   public releaseNotesFile: string;
 
   public async run(client: AppCenterClient) : Promise<CommandResult> {

--- a/test/commands/distribute/groups/publish-test.ts
+++ b/test/commands/distribute/groups/publish-test.ts
@@ -17,6 +17,7 @@ describe("distribute groups publish command", () => {
   const releaseNotes = "Fake release";
   const fakeReleaseNotesFile = "/fake/release_notes";
   const buildVersion = "123";
+  const buildNumber = "1234";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
   const originalReleaseBinaryCommandPrototype = Object.getPrototypeOf(ReleaseBinaryCommand);
 
@@ -48,7 +49,7 @@ describe("distribute groups publish command", () => {
   });
 
   it("passes all non-common parameters to distribute release", async () => {
-    const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes, "-R", fakeReleaseNotesFile]));
+    const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-n", buildNumber, "-r", releaseNotes, "-R", fakeReleaseNotesFile]));
     await command.execute();
 
     // Make sure it created a ReleaseBinaryCommand and ran it
@@ -60,6 +61,7 @@ describe("distribute groups publish command", () => {
     expect(releaseCommand.app.identifier).equals(fakeAppIdentifier);
     expect(releaseCommand.filePath).equals(fakeFilePath);
     expect(releaseCommand.buildVersion).equals(buildVersion);
+    expect(releaseCommand.buildNumber).equals(buildNumber);
     expect(releaseCommand.distributionGroup).equals(fakeGroupName);
     expect(releaseCommand.storeName).to.be.undefined;
     expect(releaseCommand.releaseNotes).equals(releaseNotes);
@@ -68,6 +70,14 @@ describe("distribute groups publish command", () => {
 
   it("returns the return value of 'distribute release'", async () => {
     const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes]));
+    const result = await command.execute();
+
+    expect(isCommandFailedResult(result)).to.be.true;
+    expect((result as CommandFailedResult).errorMessage).to.equal("Command 42 not found");
+  });
+
+  it("returns the return value of 'distribute release'", async () => {
+    const command = new PublishToGroupCommand(getCommandArgs(["-b", buildVersion, "-n", buildNumber, "-r", releaseNotes]));
     const result = await command.execute();
 
     expect(isCommandFailedResult(result)).to.be.true;

--- a/test/commands/distribute/stores/publish-test.ts
+++ b/test/commands/distribute/stores/publish-test.ts
@@ -16,7 +16,6 @@ describe("distribute stores publish command", () => {
   const fakeStoreName = "myFakeStore";
   const releaseNotes = "Fake release";
   const fakeReleaseNotesFile = "/fake/release_notes";
-  const buildVersion = "123";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
 
   let sandbox: Sinon.SinonSandbox;
@@ -46,7 +45,7 @@ describe("distribute stores publish command", () => {
   });
 
   it("passes all non-common parameters to distribute release", async () => {
-    const command = new PublishToStoreCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes, "-R", fakeReleaseNotesFile]));
+    const command = new PublishToStoreCommand(getCommandArgs(["-r", releaseNotes, "-R", fakeReleaseNotesFile]));
     await command.execute();
 
     // Make sure it created a ReleaseBinaryCommand and ran it
@@ -57,7 +56,6 @@ describe("distribute stores publish command", () => {
     const releaseCommand: FakeReleaseBinaryCommand = createReleaseStub.returnValues[0];
     expect(releaseCommand.app.identifier).equals(fakeAppIdentifier);
     expect(releaseCommand.filePath).equals(fakeFilePath);
-    expect(releaseCommand.buildVersion).equals(buildVersion);
     expect(releaseCommand.distributionGroup).to.be.undefined;
     expect(releaseCommand.storeName).equals(fakeStoreName);
     expect(releaseCommand.releaseNotes).equals(releaseNotes);
@@ -65,7 +63,7 @@ describe("distribute stores publish command", () => {
   });
 
   it("returns the return value of 'distribute release'", async () => {
-    const command = new PublishToStoreCommand(getCommandArgs(["-b", buildVersion, "-r", releaseNotes]));
+    const command = new PublishToStoreCommand(getCommandArgs(["-r", releaseNotes]));
     const result = await command.execute();
 
     expect(isCommandFailedResult(result)).to.be.true;


### PR DESCRIPTION
Groups support all file formats (except .aab) and may require build-version and build-number.
Stores don't support any file format that would require version info.

This should fix #686