### PR TITLE
Handle multiple test_env or app_env test parameters

### DIFF
--- a/src/commands/test/lib/parameters-parser.ts
+++ b/src/commands/test/lib/parameters-parser.ts
@@ -4,7 +4,14 @@ export function parseTestParameters(testParameters: string[]) {
   if (testParameters) {
     testParameters.forEach((p) => {
       const parsedParameter = parseTestParameter(p);
-      result[parsedParameter.key] = parsedParameter.value;
+      if (result[parsedParameter.key] != null && (parsedParameter.key === "test_env" || parsedParameter.key === "app_env")) {
+        const combinedValue = `${result[parsedParameter.key]}|${parsedParameter.value}`;
+        result[parsedParameter.key] = combinedValue;
+      } else if (result[parsedParameter.key] == null) {
+        result[parsedParameter.key] = parsedParameter.value;
+      } else {
+        throw new Error(`duplicate --test-parameter: ${parsedParameter.key}`);
+      }
     });
   }
 

--- a/test/commands/test/lib/parameters-parser-test.ts
+++ b/test/commands/test/lib/parameters-parser-test.ts
@@ -25,4 +25,24 @@ describe("parseTestParameters", () => {
 
     expect(parsedParameters).to.deep.equal(expected);
   });
+
+  it("should append test_env and app_env when used multiple times", () => {
+    const rawParameters = [ "key1=value1", "key2=value2", "test_env=value3", "test_env=value4", "app_env=value5", "app_env=value6" ];
+    const parsedParameters = parseTestParameters(rawParameters);
+
+    const expected = {
+      key1: "value1",
+      key2: "value2",
+      test_env: "value3|value4",
+      app_env: "value5|value6"
+    };
+
+    expect(parsedParameters).to.deep.equal(expected);
+  });
+
+  it("should refuse to append parameters other than test_env or app_env", () => {
+    const rawParameters = [ "bad_env=value1", "bad_env=value2" ];
+    expect(() => parseTestParameters(rawParameters))
+      .to.throw(Error, "duplicate --test-parameter: bad_env");
+  });
 });


### PR DESCRIPTION
Handle multiple test_env or app_env test parameters and throw an error if multiple parameters of other types are supplied