### PR TITLE
Default `buildGradle["project.ext.react"]` to empty array

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -328,7 +328,7 @@ export function getHermesEnabled(gradleFile: string): boolean {
       throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
     })
     .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"]).includes("enableHermes: true");
+      return Array.from(buildGradle["project.ext.react"] || []).includes("enableHermes: true");
     });
 }
 


### PR DESCRIPTION
It's likely an issue with our project setup, but the android codepush command fails when running:
`return Array.from(buildGradle["project.ext.react"]).includes("enableHermes: true");` because the `buildGradle["project.ext.react"]` returns a blank value.

I would like to propose defaulting the value to an empty array `[]` before performing the `.includes("enableHermes: true");` check.

Please let me know if there's any other details / tests I can/should add 😅 