### PR TITLE
Provide suggested fix in set-current token error

### DIFF
--- a/src/commands/apps/set-current.ts
+++ b/src/commands/apps/set-current.ts
@@ -33,7 +33,7 @@ export default class SetCurrentAppCommand extends Command {
 
     if (!profile) {
       return failure(ErrorCodes.InvalidParameter,
-        `Could not find a logged in profile, please note that this command is not compatible with the '--token' parameter or the token environment variable.`);
+        `Could not find a logged in profile, please note that this command is not compatible with the '--token' parameter or the token environment variable. Use environment variable 'MOBILE_CENTER_CURRENT_APP' to set the default app instead.`);
     }
 
     profile.defaultApp = newDefault;


### PR DESCRIPTION
When trying to run `appcenter apps set-current` with either `--token` or the `APPCENTER_ACCESS_TOKEN` environment variable the user receives an error saying that `set-current` doesn't support that auth mechanism. The fix is to use `MOBILE_CENTER_CURRENT_APP` but the error doesn't mention that. This PR resolves this so users know how to proceed.