### PR TITLE
[Code Push] Fix for codepush release tests

### DIFF
--- a/test/commands/codepush/codepush-release-test.ts
+++ b/test/commands/codepush/codepush-release-test.ts
@@ -37,7 +37,7 @@ describe("CodePush release tests", () => {
       .post(`/upload/upload_chunk/${releaseUploadResponse.id}`)
       .query({
         token: releaseUploadResponse.token,
-        block_number: 0
+        block_number: 1
       })
       .reply(200, {
         error: false,
@@ -58,7 +58,7 @@ describe("CodePush release tests", () => {
         state: "Done"
       });
 
-      nockedApiGatewayRequests
+    nockedApiGatewayRequests
       .post(`/${fakeParamsForRequests.appVersion}/apps/${fakeParamsForRequests.userName}/${fakeParamsForRequests.appName}/deployments/Staging/releases`, {
         release_upload: releaseUploadResponse,
         target_binary_version: "1.0",
@@ -67,20 +67,20 @@ describe("CodePush release tests", () => {
         rollout: 100
       })
       .reply(201, {
-          target_binary_range: "1.0",
-          blob_url: "storagePackage.blobUrl",
-          description: "storagePackage.description",
-          is_disabled: "storagePackage.isDisabled",
-          is_mandatory: false,
-          label: "storagePackage.label",
-          original_deployment: "storagePackage.originalDeployment",
-          original_label: "storagePackage.originalLabel",
-          package_hash: "storagePackage.packageHash",
-          released_by: "userEmail",
-          release_method: "releaseMethod",
-          rollout: 100,
-          size: 512,
-          upload_time: "uploadTime"
+        target_binary_range: "1.0",
+        blob_url: "storagePackage.blobUrl",
+        description: "storagePackage.description",
+        is_disabled: "storagePackage.isDisabled",
+        is_mandatory: false,
+        label: "storagePackage.label",
+        original_deployment: "storagePackage.originalDeployment",
+        original_label: "storagePackage.originalLabel",
+        package_hash: "storagePackage.packageHash",
+        released_by: "userEmail",
+        release_method: "releaseMethod",
+        rollout: 100,
+        size: 512,
+        upload_time: "uploadTime"
       });
 
     stubbedSign = Sinon.stub(updateContentsTasks, "sign");
@@ -93,7 +93,7 @@ describe("CodePush release tests", () => {
 
   describe("CodePush signed release", () => {
     describe("CodePush path generation", () => {
-      it("CodePush path generation for React-Native with private key", async () => {
+      it("CodePush path generation for React-Native with private key", async function () {
         // Arrange
         const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
         nockPlatformRequest("React-Native", fakeParamsForRequests, nockedApiGatewayRequests);

--- a/test/commands/codepush/codepush-release-test.ts
+++ b/test/commands/codepush/codepush-release-test.ts
@@ -93,7 +93,7 @@ describe("CodePush release tests", () => {
 
   describe("CodePush signed release", () => {
     describe("CodePush path generation", () => {
-      it("CodePush path generation for React-Native with private key", async function () {
+      it("CodePush path generation for React-Native with private key", async () => {
         // Arrange
         const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
         nockPlatformRequest("React-Native", fakeParamsForRequests, nockedApiGatewayRequests);

--- a/test/commands/codepush/utils.ts
+++ b/test/commands/codepush/utils.ts
@@ -40,7 +40,7 @@ export const setMetadataResponse = {
   chunk_size: 512,
   resume_restart: false,
   blob_partitions: 1,
-  chunk_list: [0]
+  chunk_list: [1]
 };
 
 export function createTempPathWithFakeLastFolder(nameTmpFolder: string, lastFolderName: string): string {


### PR DESCRIPTION
**Issue:** We found that 3 tests for `codepush release` commands are broken in node v12.15.0 and higher. After some investigation, it was found that the problem is in the mocking object `nockedFileUploadServiceRequests`. It contains a `chunk_list` with element 0, which is used in the `appcenter-file-upload-client` and determines the start and end position for `createReadStream`. `start` generated based on `chunk_list` takes the value -512, which leads to an error.

This PR adds a fix that allows you to run tests on node v12+

![Screen Shot 2020-03-06 at 11 34 58 AM](https://user-images.githubusercontent.com/58589743/76301773-e6505c80-62cf-11ea-9be7-4d4ebb5a72cf.png)

