### PR TITLE
[CodePush Bug] Fix react-native release

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -251,7 +251,7 @@ export function runReactNativeBundleCommand(bundleName: string, development: boo
   }
 
   Array.prototype.push.apply(reactNativeBundleArgs, [
-    path.join("node_modules", ".bin", "react-native"), "bundle",
+    path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
     "--assets-dest", outputFolder,
     "--bundle-output", path.join(outputFolder, bundleName),
     "--dev", development,

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -245,13 +245,18 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
 export function runReactNativeBundleCommand(bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string, extraBundlerOptions: string[]): Promise<void> {
   const reactNativeBundleArgs: string[] = [];
   const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
+  let cliPath: string;
 
   if (typeof envNodeArgs !== "undefined") {
     Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));
   }
-
+  if (process.platform === "darwin") {
+    cliPath = path.join("node_modules", ".bin", "react-native");
+  } else {
+    cliPath = path.join("node_modules", "react-native", "local-cli", "cli.js");
+  }
   Array.prototype.push.apply(reactNativeBundleArgs, [
-    path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
+    cliPath, "bundle",
     "--assets-dest", outputFolder,
     "--bundle-output", path.join(outputFolder, bundleName),
     "--dev", development,

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -245,18 +245,13 @@ export async function getReactNativeProjectAppVersion(versionSearchParams: Versi
 export function runReactNativeBundleCommand(bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string, extraBundlerOptions: string[]): Promise<void> {
   const reactNativeBundleArgs: string[] = [];
   const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
-  let cliPath: string;
 
   if (typeof envNodeArgs !== "undefined") {
     Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));
   }
-  if (process.platform === "darwin") {
-    cliPath = path.join("node_modules", ".bin", "react-native");
-  } else {
-    cliPath = path.join("node_modules", "react-native", "local-cli", "cli.js");
-  }
+
   Array.prototype.push.apply(reactNativeBundleArgs, [
-    cliPath, "bundle",
+    getCliPath(), "bundle",
     "--assets-dest", outputFolder,
     "--bundle-output", path.join(outputFolder, bundleName),
     "--dev", development,
@@ -401,6 +396,14 @@ function getHermesCommand(): string {
     return hermesEngine;
   }
   return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
+}
+
+function getCliPath(): string {
+  if (process.platform === "win32") {
+    return path.join("node_modules", "react-native", "local-cli", "cli.js");
+  } 
+
+  return path.join("node_modules", ".bin", "react-native");
 }
 
 export function isValidOS(os: string): boolean {

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -401,7 +401,7 @@ function getHermesCommand(): string {
 function getCliPath(): string {
   if (process.platform === "win32") {
     return path.join("node_modules", "react-native", "local-cli", "cli.js");
-  } 
+  }
 
   return path.join("node_modules", ".bin", "react-native");
 }


### PR DESCRIPTION
After #726  PR, our customers using windows faced a problem while running the `react-native release` commons (f.e. #759). The main reason of this problem is using the wrong path to `react-native-cli`

This PR fixes it for windows.
However, after this fix, the problem with the monorepository (#716) for windows users continues to be relevant