### PR TITLE
gitIgnoring visual code ide files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # IDE files
 .idea
+.vscode
 
 # Logs
 logs


### PR DESCRIPTION
Add the visual code IDE files to gitIgnore, to prevent tracking of the IDE settings of different developers.