### PR TITLE
Allow changing whether a distribution group is public.

### DIFF
--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -58,11 +58,14 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
   @hasArg
   public testersToDeleteListFile: string;
 
-  @help("Whether the distribution group is public (allowing anyone to download the releases)")
+  @help("Make the distribution group public (allowing anyone to download the releases)")
   @shortName("p")
   @longName("public")
-  @hasArg
-  public isPublic: string;
+  public makePublic: boolean;
+
+  @help("Make the distribution group private (allowing only members to download the releases)")
+  @longName("no-public")
+  public makePrivate: boolean;
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
     const app = this.app;
@@ -111,9 +114,14 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
       currentGroupName = this.distributionGroup;
     }
 
-    if (!_.isNil(this.isPublic)) {
-      debug("Setting distribution group public status to " + this.isPublic);
-      options.isPublic = JSON.parse(this.isPublic);
+    if (this.makePublic) {
+      debug("Setting distribution group public status to true");
+      options.isPublic = true;
+    }
+
+    if (this.makePrivate) {
+      debug("Setting distribution group public status to false");
+      options.isPublic = false;
     }
 
     if (!_.isNil(options.name) || !_.isNil(options.isPublic)) {
@@ -136,7 +144,8 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
       _.isNil(this.testersToAddListFile) &&
       _.isNil(this.testersToDelete) &&
       _.isNil(this.testersToDeleteListFile) &&
-      _.isNil(this.isPublic)
+      _.isNil(this.makePublic) &&
+      _.isNil(this.makePrivate)
     ) {
       throw failure(ErrorCodes.InvalidParameter, "nothing to update");
     }
@@ -146,8 +155,8 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
     if (!_.isNil(this.testersToDelete) && !_.isNil(this.testersToDeleteListFile)) {
       throw failure(ErrorCodes.InvalidParameter, "parameters 'delete-testers' and 'delete-testers-file' are mutually exclusive");
     }
-    if (!_.isNil(this.isPublic) && this.isPublic.toLowerCase() !== "true" && this.isPublic.toLowerCase() !== "false") {
-      throw failure(ErrorCodes.InvalidParameter, "boolean parameter 'is-public' must be either 'true' or 'false'");
+    if (this.makePublic && this.makePrivate) {
+      throw failure(ErrorCodes.InvalidParameter, "parameters 'public' and 'no-public' are mutually exclusive");
     }
   }
 

--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -58,13 +58,13 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
   @hasArg
   public testersToDeleteListFile: string;
 
-  @help("Make the distribution group public (allowing anyone to download the releases)")
+  @help("Make the distribution group public (allowing anyone to download the releases). Don't use with opposite --private.")
   @shortName("p")
   @longName("public")
   public makePublic: boolean;
 
-  @help("Make the distribution group private (allowing only members to download the releases)")
-  @longName("no-public")
+  @help("Make the distribution group private (allowing only members to download the releases). Don't use with opposite --public.")
+  @longName("private")
   public makePrivate: boolean;
 
   public async run(client: AppCenterClient): Promise<CommandResult> {

--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -60,7 +60,7 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
 
   @help("Whether the distribution group is public (allowing anyone to download the releases)")
   @shortName("p")
-  @longName("isPublic")
+  @longName("public")
   @hasArg
   public isPublic: string;
 

--- a/test/commands/distribute/groups/update-test.ts
+++ b/test/commands/distribute/groups/update-test.ts
@@ -56,13 +56,35 @@ describe("distribute groups update command", () => {
     testCommandSuccess(result, executionScope, skippedScope);
   });
 
+  it("can make a group public", async () => {
+    // Arrange
+    const executionScope = setupDistributionGroupUpdateResponse(Nock(fakeHost), { is_public: true });
+
+    // Act
+    const command = new UpdateDistributionGroupCommand(getCommandArgs(["-g", fakeDistributionGroupName, "--public"]));
+    const result = await command.execute();
+
+    // Assert
+    testCommandSuccess(result, executionScope);
+  });
+
+  it("can make a group private", async () => {
+    // Arrange
+    const executionScope = setupDistributionGroupUpdateResponse(Nock(fakeHost), { is_public: false });
+
+    // Act
+    const command = new UpdateDistributionGroupCommand(getCommandArgs(["-g", fakeDistributionGroupName, "--private"]));
+    const result = await command.execute();
+
+    // Assert
+    testCommandSuccess(result, executionScope);
+  });
+
   it("can rename a group and set its public status at the same time", async () => {
     // Arrange
-    const newIsPublic = true;
     const executionScope = setupDistributionGroupNotFoundResponse(
-      setupDistributionGroupUpdateNameAndPublicResponse(Nock(fakeHost), updatedFakeDistributionGroupName, newIsPublic)
+      setupDistributionGroupUpdateResponse(Nock(fakeHost), { name: updatedFakeDistributionGroupName, is_public: true })
     );
-    const skippedScope = setupDistributionGroupFoundResponse(Nock(fakeHost));
 
     // Act
     const command = new UpdateDistributionGroupCommand(
@@ -71,14 +93,15 @@ describe("distribute groups update command", () => {
     const result = await command.execute();
 
     // Assert
-    testCommandSuccess(result, executionScope, skippedScope);
+    testCommandSuccess(result, executionScope);
   });
 
   it("doesn't change the public status of a group when neither related switches are provided", async () => {
     // Arrange
-    const newIsPublic = true;
     const executionScope = setupDistributionGroupNotFoundResponse(
-      setupDistributionGroupUpdateNameOnlyResponse(Nock(fakeHost), updatedFakeDistributionGroupName, newIsPublic)
+      setupDistributionGroupUpdateResponse(Nock(fakeHost), {
+        name: updatedFakeDistributionGroupName,
+      })
     );
     const skippedScope = setupDistributionGroupFoundResponse(Nock(fakeHost));
 
@@ -103,7 +126,9 @@ describe("distribute groups update command", () => {
   function testCommandSuccess(result: CommandResult, executionScope: Nock.Scope, abortScope?: Nock.Scope) {
     console.log(result);
     expect(result.succeeded).to.eql(true, "Command should be successfully completed");
-    expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    if (abortScope) {
+      expect(abortScope.isDone()).to.eql(false, "Unexpected requests were made");
+    }
     executionScope.done(); // All normal API calls are executed
   }
 
@@ -144,44 +169,16 @@ describe("distribute groups update command", () => {
       });
   }
 
-  function setupDistributionGroupUpdateResponse(nockScope: Nock.Scope) {
-    return nockScope.patch(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}`).reply(200, {
-      id: "7dbdfd81-342b-4a38-a4dd-d05379abe19d",
-      name: updatedFakeDistributionGroupName,
-      origin: "appcenter",
-      display_name: updatedFakeDistributionGroupName,
-      is_public: false,
-    });
-  }
-
-  function setupDistributionGroupUpdateNameAndPublicResponse(nockScope: Nock.Scope, newName: string, newIsPublic: boolean) {
+  function setupDistributionGroupUpdateResponse(nockScope: Nock.Scope, options: { name?: string; is_public?: boolean }) {
     return nockScope
       .log(console.log)
-      .patch(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}`, {
-        name: newName,
-        is_public: newIsPublic,
-      })
+      .patch(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}`, options)
       .reply(200, {
         id: "7dbdfd81-342b-4a38-a4dd-d05379abe19d",
-        name: newName,
+        name: options?.name ?? fakeDistributionGroupName,
         origin: "appcenter",
-        display_name: newName,
-        is_public: newIsPublic,
-      });
-  }
-
-  function setupDistributionGroupUpdateNameOnlyResponse(nockScope: Nock.Scope, newName: string, newIsPublic: boolean) {
-    return nockScope
-      .log(console.log)
-      .patch(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}`, {
-        name: newName,
-      })
-      .reply(200, {
-        id: "7dbdfd81-342b-4a38-a4dd-d05379abe19d",
-        name: newName,
-        origin: "appcenter",
-        display_name: newName,
-        is_public: newIsPublic,
+        display_name: options?.name ?? fakeDistributionGroupName,
+        is_public: options?.is_public ?? false,
       });
   }
 });


### PR DESCRIPTION
Add `public` and `private` switches to `distribute groups update`. These allow making a group public or the opposite.

Resolves #642.