### PR TITLE
Fix react-native build with hermes enabled on Windows

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -438,6 +438,15 @@ function getHermesOSBin(): string {
   }
 }
 
+function getHermesOSExe(): string {
+  switch (process.platform) {
+    case "win32":
+      return ".exe";
+    default:
+      return "";
+  }
+}
+
 function getHermesCommand(): string {
   const fileExists = (file: string): boolean => {
     try {
@@ -447,7 +456,7 @@ function getHermesCommand(): string {
     }
   };
   // assume if hermes-engine exists it should be used instead of hermesvm
-  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), "hermes");
+  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), `hermes${getHermesOSExe()}`);
   if (fileExists(hermesEngine)) {
     return hermesEngine;
   }

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -441,9 +441,9 @@ function getHermesOSBin(): string {
 function getHermesOSExe(): string {
   switch (process.platform) {
     case "win32":
-      return ".exe";
+      return "hermes.exe";
     default:
-      return "";
+      return "hermes";
   }
 }
 
@@ -456,7 +456,7 @@ function getHermesCommand(): string {
     }
   };
   // assume if hermes-engine exists it should be used instead of hermesvm
-  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), `hermes${getHermesOSExe()}`);
+  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
   if (fileExists(hermesEngine)) {
     return hermesEngine;
   }


### PR DESCRIPTION
This should fixes #693.

For now, we can't deploy a react-native release on Windows with hermes enabled because the script looks for an executable file without a `.exe` file extension, whereas on Windows, we need a `.exe` extension, throwing an ENOENT error.

![image](https://user-images.githubusercontent.com/1584563/79579562-068deb00-80c8-11ea-8fed-0c65cdde7fbe.png)

Full error:
```
Error: spawn node_modules\hermesvm\win64-bin\hermes ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:264:19)
    at onErrorNT (internal/child_process.js:456:16)
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
Emitted 'error' event at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:270:12)
    at onErrorNT (internal/child_process.js:456:16)
    at processTicksAndRejections (internal/process/task_queues.js:77:11) {
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawn node_modules\\hermesvm\\win64-bin\\hermes',
  path: 'node_modules\\hermesvm\\win64-bin\\hermes',
  spawnargs: [
    '-emit-binary',
    '-out',
    'C:\\Users\\shywi\\AppData\\Local\\Temp\\code-push2020317-23456-1rdxgc2.ndt9\\CodePush\\index.android.bundle.hbc',      'C:\\Users\\shywi\\AppData\\Local\\Temp\\code-push2020317-23456-1rdxgc2.ndt9\\CodePush\\index.android.bundle',          '-w'
  ]
}
```

This PR add a function to look for platform specific executable file extension.
