### PR TITLE
Fix reference to wrong name of parameter

### DIFF
--- a/src/commands/distribute/groups/update.ts
+++ b/src/commands/distribute/groups/update.ts
@@ -156,7 +156,7 @@ export default class UpdateDistributionGroupCommand extends AppCommand {
       throw failure(ErrorCodes.InvalidParameter, "parameters 'delete-testers' and 'delete-testers-file' are mutually exclusive");
     }
     if (this.makePublic && this.makePrivate) {
-      throw failure(ErrorCodes.InvalidParameter, "parameters 'public' and 'no-public' are mutually exclusive");
+      throw failure(ErrorCodes.InvalidParameter, "parameters 'public' and 'private' are mutually exclusive");
     }
   }
 


### PR DESCRIPTION
The `private` switch of `distribute groups update` was meant to be called `no-public` until we discovered this won't work with the current design. There is still an error message referring to it under this name. This changes that.