### PR TITLE
Run autorest with 16Gb

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch-test": "mocha --require ts-node/register ./test/**/*-test.[tj]s --watch",
     "autorest:clean": "rimraf src/util/apis/generated",
     "autorest": "npm run autorest:clean && node scripts/autorest.js",
-    "autorest:gen": "node --max-old-space-size=16384 node_modules/.bin/autorest --debug swagger/readme.md",
+    "autorest:gen": "node --max-old-space-size=16384 node_modules/autorest/dist/app.js --debug swagger/readme.md",
     "clean": "gulp clean",
     "prepublishOnly": "npm run lint && gulp prepublish",
     "download-swagger": "gulp download-swagger",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "watch-test": "mocha --require ts-node/register ./test/**/*-test.[tj]s --watch",
     "autorest:clean": "rimraf src/util/apis/generated",
     "autorest": "npm run autorest:clean && node scripts/autorest.js",
+    "autorest:gen": "node --max-old-space-size=16384 node_modules/bin/autorest --debug swagger/readme.md",
     "clean": "gulp clean",
     "prepublishOnly": "npm run lint && gulp prepublish",
     "download-swagger": "gulp download-swagger",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch-test": "mocha --require ts-node/register ./test/**/*-test.[tj]s --watch",
     "autorest:clean": "rimraf src/util/apis/generated",
     "autorest": "npm run autorest:clean && node scripts/autorest.js",
-    "autorest:gen": "node --max-old-space-size=16384 node_modules/bin/autorest --debug swagger/readme.md",
+    "autorest:gen": "node --max-old-space-size=16384 node_modules/.bin/autorest --debug swagger/readme.md",
     "clean": "gulp clean",
     "prepublishOnly": "npm run lint && gulp prepublish",
     "download-swagger": "gulp download-swagger",

--- a/scripts/autorest.js
+++ b/scripts/autorest.js
@@ -20,9 +20,11 @@ function runAutorest() {
   console.log(`Running ${autorestScript} "${configFilePath}"`);
 
   return new Promise((resolve, reject) => {
-    const arp = childProcess.spawn(path.join(__dirname, "..", "node_modules", ".bin", autorestScript), [configFilePath], {
-      cwd: path.join(__dirname, ".."),
-    });
+    const arp = childProcess.spawn(
+      "node",
+      ["--max-old-space-size=16384", path.join(__dirname, "..", "node_modules", ".bin", autorestScript), configFilePath, "--debug"],
+      { cwd: path.join(__dirname, "..") }
+    );
 
     arp.stdout.on("data", (data) => console.log(data.toString()));
     arp.stderr.on("error", (data) => console.error(data.toString()));


### PR DESCRIPTION
Here's a first PR that actually solves running Autorest (version 2) using 16Gb of memory for node.
Tested with node 10.
A follow-up PR will update the client APIs.