### PR TITLE
Explicitly specify JS for Code analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,12 +22,9 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      with:
+        languages: javascript
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below).
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
 


### PR DESCRIPTION
As part of https://github.com/microsoft/appcenter-cli/pull/840 I used the autobuild feature which yielded Java. Manually specifying JavaScript (TypeScript) only.

This fixes https://github.com/microsoft/appcenter-cli/runs/629079947

Apologies for the double PRs, but this only surfaced after the PR was merged.