### PR TITLE
Check for `null` user before using its properties

### DIFF
--- a/src/commands/apps/get-current.ts
+++ b/src/commands/apps/get-current.ts
@@ -10,7 +10,7 @@ export default class GetCurrentAppCommand extends Command {
 
   async runNoClient(): Promise<CommandResult> {
     const user = getUser();
-    const currentApp = user.defaultApp ? `${user.defaultApp.ownerName}/${user.defaultApp.appName}` : "";
+    const currentApp = user?.defaultApp ? `${user.defaultApp.ownerName}/${user.defaultApp.appName}` : "";
     out.text((s) => s, currentApp);
     return success();
   }

--- a/src/commands/lib/logout.ts
+++ b/src/commands/lib/logout.ts
@@ -13,7 +13,7 @@ export async function logout(client: AppCenterClient, user: Profile): Promise<vo
 
 async function performLogout(client: AppCenterClient, user: Profile): Promise<void> {
   // Only delete token off the server if CLI created it.
-  if (!user.tokenSuppliedByUser) {
+  if (!user?.tokenSuppliedByUser) {
     let tokenId: string;
     try {
       await Promise.race([

--- a/src/util/commandline/app-command.ts
+++ b/src/util/commandline/app-command.ts
@@ -35,7 +35,7 @@ export class AppCommand extends Command {
       // Default app in profile
     } else {
       const profile = getUser();
-      if (profile.defaultApp) {
+      if (profile?.defaultApp) {
         result = profile.defaultApp;
 
         // Couldn't find one, fail.


### PR DESCRIPTION
The user (profile) will be `null` when using the `APPCENTER_ACCESS_TOKEN` environment variable.

Resolves #844.