### PR TITLE
Add `orgs apps create` command.

### DIFF
--- a/src/commands/apps/lib/format-app.ts
+++ b/src/commands/apps/lib/format-app.ts
@@ -15,7 +15,7 @@ export function reportApp(app: models.AppResponse): void {
       ["Owner Display Name", "owner.displayName"],
       ["Owner Email", "owner.email"],
       ["Owner Name", "owner.name"],
-      ["Azure Subscription ID", "azureSubscriptionId"],
+      ["Azure Subscription ID", "azureSubscription.subscriptionId"],
     ],
     app
   );

--- a/src/commands/orgs/apps/create.ts
+++ b/src/commands/orgs/apps/create.ts
@@ -1,0 +1,116 @@
+import {
+  Command,
+  CommandResult,
+  CommandArgs,
+  ErrorCodes,
+  failure,
+  hasArg,
+  help,
+  longName,
+  required,
+  shortName,
+  success,
+} from "../../../util/commandline";
+import { AppCenterClient, clientRequest, models } from "../../../util/apis";
+import { out } from "../../../util/interaction";
+import { reportApp } from "../../apps/lib/format-app";
+import { APP_RELEASE_TYPE_VALIDATIONS } from "../../apps/lib/app-release-type-validation";
+
+@help("Create a new app in an organization")
+export default class OrgAppCreateCommand extends Command {
+  constructor(args: CommandArgs) {
+    super(args);
+  }
+
+  @help("Name of the organization")
+  @shortName("n")
+  @longName("org-name")
+  @required
+  @hasArg
+  orgName: string;
+
+  @help(
+    "The name of the app used in URLs. Can optionally be provided specifically, otherwise a generated name will be derived from display-name"
+  )
+  @shortName("a")
+  @longName("app-name")
+  @hasArg
+  appName: string;
+
+  @help("Description of the app")
+  @longName("description")
+  @hasArg
+  description: string;
+
+  @help("The descriptive name of the app. This can contain any characters")
+  @shortName("d")
+  @longName("display-name")
+  @required
+  @hasArg
+  displayName: string;
+
+  @help("The OS the app will be running on. Supported values: Android, Custom, iOS, macOS, tvOS, Windows")
+  @shortName("o")
+  @longName("os")
+  @required
+  @hasArg
+  os: string;
+
+  @help(
+    "The platform of the app. Supported values: Cordova, Java, Objective-C-Swift, React-Native, Unity, UWP, WinForms, WPF, Xamarin, Custom"
+  )
+  @shortName("p")
+  @longName("platform")
+  @required
+  @hasArg
+  platform: string;
+
+  @help(
+    "The app release type. Suggested values are Alpha, Beta, Production, Store, Enterprise. Custom values are allowed and must be must be one word, alphanumeric, first letter capitalized."
+  )
+  @shortName("r")
+  @longName("release-type")
+  @hasArg
+  release_type: string;
+
+  async run(client: AppCenterClient): Promise<CommandResult> {
+    const appAttributes: models.AppRequest = {
+      displayName: this.displayName,
+      platform: this.platform,
+      os: this.os,
+      description: this.description,
+      name: this.appName,
+    };
+
+    if (this.release_type) {
+      if (this.release_type.length > APP_RELEASE_TYPE_VALIDATIONS.maxLength.rule) {
+        return failure(ErrorCodes.InvalidParameter, APP_RELEASE_TYPE_VALIDATIONS.maxLength.errorMessage);
+      }
+      if (!APP_RELEASE_TYPE_VALIDATIONS.matchRegexp.rule.test(this.release_type)) {
+        return failure(ErrorCodes.InvalidParameter, APP_RELEASE_TYPE_VALIDATIONS.matchRegexp.errorMessage);
+      }
+      appAttributes.releaseType = this.release_type;
+    }
+
+    const createAppResponse = await out.progress(
+      "Creating app in org...",
+      clientRequest<models.AppResponse>((cb) => client.appsOperations.createForOrg(this.orgName, appAttributes, cb))
+    );
+
+    const statusCode = createAppResponse.response.statusCode;
+    if (statusCode >= 400) {
+      switch (statusCode) {
+        case 400:
+          return failure(ErrorCodes.Exception, "the request was rejected for an unknown reason");
+        case 404:
+          return failure(ErrorCodes.NotFound, "there appears to be no such org");
+        case 409:
+          return failure(ErrorCodes.InvalidParameter, "an app with this 'name' already exists");
+      }
+    }
+
+    reportApp(createAppResponse.result);
+
+    return success();
+  }
+}

--- a/test/commands/orgs/apps/create-test.ts
+++ b/test/commands/orgs/apps/create-test.ts
@@ -1,0 +1,137 @@
+import { assert } from "chai";
+import * as Nock from "nock";
+import * as Sinon from "sinon";
+
+import OrgsAppsCreateCommand from "../../../../src/commands/orgs/apps/create";
+import { out } from "../../../../src/util/interaction";
+import { CommandArgs, CommandFailedResult } from "../../../../src/util/commandline";
+
+describe("orgs apps create command", () => {
+  const fakeOrgName = "ClandestineOrganization17";
+  const fakeAppName = "fakeAppName";
+  const fakeAppDisplayName = "Above Board Operations";
+  const fakeAppDescription = "Lorem, lorem! Put words.";
+  const fakeAppOs = "Android";
+  const fakeAppPlatform = "Java";
+  const fakeAppReleaseType = "Gamma";
+  const fakeHost = "http://localhost:1700";
+  const fakeOrgId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+  const fakeOrgEmail = "info@fake.org";
+  const fakeToken = "fd6327f9-198c-4161-8127-dd445b727601";
+
+  const orgsAppCreateUrl = `/v0.1/orgs/${fakeOrgName}/apps`;
+
+  // The name formatting is that returned by the method we call, not the API itself (that uses underscores)
+  const fakeAppResponse = {
+    description: fakeAppDescription,
+    name: fakeAppName,
+    os: fakeAppOs,
+    owner: {
+      id: fakeOrgId,
+      email: fakeOrgEmail,
+      name: fakeOrgName,
+      type: "org",
+    },
+    platform: fakeAppPlatform,
+  };
+
+  let sandbox: Sinon.SinonSandbox;
+  let reportStub: Sinon.SinonStub;
+  let nockScope: Nock.Scope;
+
+  const command = getOrgsAppsCreateCommand(
+    `--org-name ${fakeOrgName} --app-name ${fakeAppName} --os ${fakeAppOs} --platform ${fakeAppPlatform} --release-type ${fakeAppReleaseType}`,
+    ["--description", fakeAppDescription, "--display-name", fakeAppDisplayName]
+  );
+
+  before(() => {
+    sandbox = Sinon.createSandbox();
+    Nock.disableNetConnect();
+  });
+
+  beforeEach(() => {
+    reportStub = sandbox.stub(out, "report");
+    nockScope = Nock(fakeHost);
+  });
+
+  afterEach(() => {
+    nockScope.done();
+    sandbox.restore();
+    Nock.cleanAll();
+  });
+
+  after(() => {
+    Nock.enableNetConnect();
+  });
+
+  describe("when creating an app with all valid settings", () => {
+    beforeEach(() => {
+      nockScope
+        .post(orgsAppCreateUrl, {
+          description: fakeAppDescription,
+          release_type: fakeAppReleaseType,
+          display_name: fakeAppDisplayName,
+          name: fakeAppName,
+          os: fakeAppOs,
+          platform: fakeAppPlatform,
+        })
+        .reply(200, fakeAppResponse);
+    });
+
+    it("reports the command as succeeded", async () => {
+      const result = await command.execute();
+
+      assert(result.succeeded, `Result should be success. Got result: ${JSON.stringify(result)}`);
+    });
+
+    it("writes out the app details", async () => {
+      await command.execute();
+
+      Sinon.assert.calledWithMatch(reportStub, Sinon.match.any, fakeAppResponse);
+    });
+  });
+
+  describe("when status 404 is returned", () => {
+    beforeEach(() => {
+      nockScope.post(orgsAppCreateUrl).reply(404, { error: { code: "NotFound", message: "Some error" } });
+    });
+
+    it("fails", async () => {
+      const result = await command.execute();
+
+      assert.isFalse(result.succeeded);
+    });
+
+    it("reports the org doesn't exist", async () => {
+      const result = (await command.execute()) as CommandFailedResult;
+      assert.equal(result.errorMessage, "there appears to be no such org");
+    });
+  });
+
+  describe("when status 409 is returned", () => {
+    beforeEach(() => {
+      nockScope.post(orgsAppCreateUrl).reply(409, { error: { code: "Conflict", message: "Some error" } });
+    });
+
+    it("fails", async () => {
+      const result = await command.execute();
+
+      assert.isFalse(result.succeeded);
+    });
+
+    it("reports another app with the same name already exists", async () => {
+      const result = (await command.execute()) as CommandFailedResult;
+      assert.equal(result.errorMessage, "an app with this 'name' already exists");
+    });
+  });
+
+  function getOrgsAppsCreateCommand(parameters: string, whitespaceParameters?: string[]): OrgsAppsCreateCommand {
+    const cliArgs: string[] = parameters.split(" ").concat(whitespaceParameters).concat("--env", "local", "--token", fakeToken);
+    const constructorArgs: CommandArgs = {
+      args: cliArgs,
+      command: ["orgs", "apps", "create"],
+      commandPath: "FAKE",
+    };
+    return new OrgsAppsCreateCommand(constructorArgs);
+  }
+});


### PR DESCRIPTION
It's a clone of `apps create`, except it catches exceptions for nicer user errors and has unit tests. Functional tests probably would have been better, but/since that required creating `orgs delete` and `orgs apps delete` commands as well.

Resolves #831.
Involves #712.