### PR TITLE
Minor update to `distribute releases edit-notes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Below is the list of commands currently supported by Visual Studio App Center CL
 | `appcenter distribute groups update` | Update existing distribution group |
 | `appcenter distribute releases add-destination` | Distribute an existing release to an additional destination |
 | `appcenter distribute releases delete` | Deletes the release |
+| `appcenter distribute releases edit-notes` | Update release notes |
 | `appcenter distribute releases edit` | Toggles enabling and disabling the specified release |
 | `appcenter distribute releases list` | Shows the list of all releases for the application |
 | `appcenter distribute releases show` | Shows full details about release |

--- a/src/commands/distribute/releases/edit-notes.ts
+++ b/src/commands/distribute/releases/edit-notes.ts
@@ -19,7 +19,7 @@ import * as _ from "lodash";
 
 const debug = require("debug")("appcenter-cli:commands:distribute:releases:edit-notes");
 
-@help("Updating release notes")
+@help("Update release notes")
 export default class EditReleaseCommand extends AppCommand {
   @help("Release ID")
   @shortName("r")
@@ -81,11 +81,11 @@ export default class EditReleaseCommand extends AppCommand {
         )
       );
       if (httpResponse.response.statusCode >= 400) {
-        return failure(ErrorCodes.Exception, `failed to update the relese notes`);
+        return failure(ErrorCodes.Exception, `failed to update the release notes`);
       }
     } catch (error) {
       debug(`Failed to update the release - ${inspect(error)}`);
-      return failure(ErrorCodes.Exception, `failed to update the relese notes`);
+      return failure(ErrorCodes.Exception, `failed to update the release notes`);
     }
     out.text(`Release ${releaseDetails.shortVersion} (${releaseDetails.version}) with id: ${this.releaseId} has been updated`);
     return success();
@@ -110,7 +110,9 @@ export default class EditReleaseCommand extends AppCommand {
   private validateParameters(): void {
     debug("Checking for invalid parameter combinations");
     if (!_.isNil(this.releaseNotes) && !_.isNil(this.releaseNotesFile)) {
-      throw failure(ErrorCodes.InvalidParameter, "'--release-notes' and '--release-notes-file' switches are mutually exclusive");
+      throw failure(ErrorCodes.InvalidParameter, "'--release-notes' and '--release-notes-file' parameters are mutually exclusive");
+    } else if (_.isNil(this.releaseNotes) && _.isNil(this.releaseNotesFile)) {
+      throw failure(ErrorCodes.InvalidParameter, "One of '--release-notes' and '--release-notes-file' is required");
     }
   }
 }


### PR DESCRIPTION
Add the command to the readme.
Require exactly one of the release notes parameters.