### PR TITLE
Version 2.5.2 with hotfix for login and edit-notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
Changes:
- Added new command `appcenter distribute releases edit-notes` by @Vacxe in #853 
- Reverted `uuid` to v7 to fix issues with `appcenter login` on some platforms, see #861 