### PR TITLE
Fix "isOrg" check in test command

### DIFF
--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -72,13 +72,8 @@ export class TestCloudUploader {
   }
 
   public async uploadAndStart(): Promise<StartedTestRun> {
-    const orgs = await getOrgsNamesList(this._client);
-    let isOrg = false;
-    for (const org of orgs) {
-      if (org.name === this._userName) {
-        isOrg = true;
-      }
-    }
+    const app = await this._client.appsOperations.get(this._userName, this._appName);
+    const isOrg = app.owner.type === "org";
 
     const manifest = await progressWithResult<TestManifest>("Validating arguments", this.validateAndParseManifest());
 

--- a/src/commands/test/lib/test-cloud-uploader.ts
+++ b/src/commands/test/lib/test-cloud-uploader.ts
@@ -3,7 +3,6 @@ import { progressWithResult } from "./interaction";
 import { TestManifest, TestRunFile } from "./test-manifest";
 import { TestManifestReader } from "./test-manifest-reader";
 import { AppValidator } from "./app-validator";
-import { getOrgsNamesList } from "../../orgs/lib/org-users-helper";
 import * as PortalHelper from "../../../util/portal/portal-helper";
 import * as _ from "lodash";
 import * as fs from "fs";


### PR DESCRIPTION
Get app info to determine if owner is org instead of listing all orgs. This will allow App API token usage with the `test` commands.