### PR TITLE
Fix functional tests: require pester 4.x

### DIFF
--- a/test/functional/Invoke-FunctionalTests.ps1
+++ b/test/functional/Invoke-FunctionalTests.ps1
@@ -28,7 +28,7 @@ function Get-Root {
 
 if (!(Get-Module -ListAvailable -Name Pester)) {
   Write-Host "Installing Pester"
-  Install-Module -Name Pester -Force -SkipPublisherCheck
+  Install-Module -Name Pester -Force -SkipPublisherCheck -RequiredVersion 4.9.0
 }
 
 Import-Module Pester


### PR DESCRIPTION
We have the following WARNING with latest Pester:
> You are using Legacy parameter set that adapts Pester 5 syntax to Pester 4 syntax. This parameter set is deprecated, and does not work 100%. The -Strict and -PesterOption parameters are ignored, and providing advanced configuration to -Path (-Script), and -CodeCoverage via a hash table does not work. Please refer to https://github.com/pester/Pester/releases/tag/5.0.1#legacy-parameter-set for more information.

This then leads to the following error:
```
[-] distribute release.creates a release when mandatory flag is set to true 1.26s (1.26s|3ms)
 JsonReaderException: Unexpected character encountered while parsing value: E. Path '', line 0, position 0.
 ArgumentException: Conversion from JSON failed with error: Unexpected character encountered while parsing value: E. Path '', line 0, position 0.
 at <ScriptBlock>, /home/vsts/work/1/s/test/functional/commands/distribute/Release.Tests.ps1:26
```

After some debugging, it was found that pester 4 solves the issue.
Let's stick to it for now.