### PR TITLE
Use token parameter in release command

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -346,10 +346,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const profile = getUser();
     const url = getPortalUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName);
     let accessToken = "";
-    if (profile) {
+    if (this.token) {
+      accessToken = this.token;
+    } else if (profile) {
       accessToken = await profile.accessToken;
     }
-    accessToken = this.token;
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -404,10 +405,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const profile = getUser();
     const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
     let accessToken = "";
-    if (profile) {
+    if (this.token) {
+      accessToken = this.token;
+    } else if (profile) {
       accessToken = await profile.accessToken;
     }
-    accessToken = this.token;
     const response = await fetch(url, {
       method: "PATCH",
       headers: {
@@ -449,10 +451,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
       const profile = getUser();
       const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
       let accessToken = "";
-      if (profile) {
+      if (this.token) {
+        accessToken = this.token;
+      } else if (profile) {
         accessToken = await profile.accessToken;
       }
-      accessToken = this.token;
       const response = await fetch(url, {
         method: "GET",
         headers: {

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -345,10 +345,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Creating release upload");
     const profile = getUser();
     const url = getPortalUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName);
-    let accessToken = this.token;
+    let accessToken = ""
     if (profile) {
       accessToken = await profile.accessToken;
     }
+    accessToken = this.token;
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -402,10 +403,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Patching the upload");
     const profile = getUser();
     const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-    let accessToken = this.token;
+    let accessToken = ""
     if (profile) {
       accessToken = await profile.accessToken;
     }
+    accessToken = this.token;
     const response = await fetch(url, {
       method: "PATCH",
       headers: {
@@ -446,10 +448,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
       debug("Loading release id...");
       const profile = getUser();
       const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-      let accessToken = this.token;
+      let accessToken = ""
       if (profile) {
         accessToken = await profile.accessToken;
       }
+      accessToken = this.token;
       const response = await fetch(url, {
         method: "GET",
         headers: {

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -345,7 +345,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Creating release upload");
     const profile = getUser();
     const url = getPortalUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName);
-    let accessToken = ""
+    let accessToken = "";
     if (profile) {
       accessToken = await profile.accessToken;
     }
@@ -403,7 +403,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Patching the upload");
     const profile = getUser();
     const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-    let accessToken = ""
+    let accessToken = "";
     if (profile) {
       accessToken = await profile.accessToken;
     }
@@ -448,7 +448,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
       debug("Loading release id...");
       const profile = getUser();
       const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-      let accessToken = ""
+      let accessToken = "";
       if (profile) {
         accessToken = await profile.accessToken;
       }

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -345,7 +345,10 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Creating release upload");
     const profile = getUser();
     const url = getPortalUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName);
-    const accessToken = await profile.accessToken;
+    let accessToken = this.token;
+    if (profile) {
+      accessToken = await profile.accessToken;
+    }
     const response = await fetch(url, {
       method: "POST",
       headers: {
@@ -399,7 +402,10 @@ export default class ReleaseBinaryCommand extends AppCommand {
     debug("Patching the upload");
     const profile = getUser();
     const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-    const accessToken = await profile.accessToken;
+    let accessToken = this.token;
+    if (profile) {
+      accessToken = await profile.accessToken;
+    }
     const response = await fetch(url, {
       method: "PATCH",
       headers: {
@@ -440,7 +446,10 @@ export default class ReleaseBinaryCommand extends AppCommand {
       debug("Loading release id...");
       const profile = getUser();
       const url = getPortalPatchUploadLink(environments(this.environmentName).endpoint, app.ownerName, app.appName, uploadId);
-      const accessToken = await profile.accessToken;
+      let accessToken = this.token;
+      if (profile) {
+        accessToken = await profile.accessToken;
+      }
       const response = await fetch(url, {
         method: "GET",
         headers: {


### PR DESCRIPTION
This PR makes sure that a `--token` parameter is used when specified.
This also fixes several unit tests which were failing if user is not logged in on the machine.