### PR TITLE
Fix getting the proper endpoint

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -471,7 +471,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
       endpoint = profile.endpoint;
     } else {
       endpoint = environments(this.environmentName).endpoint;
-    } 
+    }
     return endpoint;
   }
 

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -467,11 +467,11 @@ export default class ReleaseBinaryCommand extends AppCommand {
 
   private async getEndpoint(profile: Profile): Promise<string> {
     let endpoint = "";
-    if (this.environmentName) {
-      endpoint = environments(this.environmentName).endpoint;
-    } else if (profile) {
+    if (profile) {
       endpoint = profile.endpoint;
-    }
+    } else {
+      endpoint = environments(this.environmentName).endpoint;
+    } 
     return endpoint;
   }
 


### PR DESCRIPTION
This kind of logic introduced a bug before:
- Logout
- Use distribute command with the token provided
- Endpoint is undefined.