### PR TITLE
Add dependabot.yml to enable dependabot beta

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every weekday
+    # Check the npm registry for updates every week
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every week
+    # Check the npm registry for updates every weekday
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml.
+++ b/.github/dependabot.yml.
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every week
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml.
+++ b/.github/dependabot.yml.
@@ -6,4 +6,4 @@ updates:
     directory: "/"
     # Check the npm registry for updates every week
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/dependabot.yml.
+++ b/.github/dependabot.yml.
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
-    # Check the npm registry for updates every weekday
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Dependabot version update is now in beta, see post at:
https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Once this flow has been validated, we can remove the dependabot-preview app.
We may have to check in some changes to tell dependabot not to ignore this or that package, as we've previously done with comment in the PRs raised. With a bit of luck, the bot will have the right to run builds on azure pipelines.

See also:
- https://help.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
- https://help.github.com/en/github/administering-a-repository/customizing-dependency-updates