### PR TITLE
feat: Use the original "sourcemap" and "sourcemap.hbc.map" to generate a real sourcemap

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -399,25 +399,22 @@ export function runHermesEmitBinaryCommand(
       });
     });
   }).then(() => {
-    if (!sourcemapOutput) return null;
+    if (!sourcemapOutput) {
+      return null;
+    }
 
     const composeSourceMapsPath = getComposeSourceMapsPath();
     if (!composeSourceMapsPath) {
-      throw new Error('react-native compose-source-maps.js scripts is not found');
+      throw new Error("react-native compose-source-maps.js scripts is not found");
     }
 
     const jsCompilerSourceMapFile = path.join(outputFolder, bundleName + ".hbc" + ".map");
     if (!fs.existsSync(jsCompilerSourceMapFile)) {
-      throw new Error('sourcemap file is not found');
+      throw new Error("sourcemap file is not found");
     }
 
     return new Promise<void>((resolve, reject) => {
-      const composeSourceMapsArgs = [
-        sourcemapOutput,
-        jsCompilerSourceMapFile,
-        "-o",
-        sourcemapOutput,
-      ];
+      const composeSourceMapsArgs = [sourcemapOutput, jsCompilerSourceMapFile, "-o", sourcemapOutput];
 
       // https://github.com/facebook/react-native/blob/master/react.gradle#L211
       // index.android.bundle.packager.map + index.android.bundle.compiler.map = index.android.bundle.map
@@ -429,14 +426,12 @@ export function runHermesEmitBinaryCommand(
       });
 
       composeSourceMapsProcess.stderr.on("data", (data: Buffer) => {
-          console.error(data.toString().trim());
+        console.error(data.toString().trim());
       });
 
       composeSourceMapsProcess.on("close", (exitCode: number) => {
         if (exitCode) {
-          reject(
-              new Error(`"compose-source-maps" command exited with code ${exitCode}.`)
-          );
+          reject(new Error(`"compose-source-maps" command exited with code ${exitCode}.`));
         }
 
         // Delete the HBC sourceMap, otherwise it will be included in 'code-push' bundle as well
@@ -516,10 +511,10 @@ function getHermesCommand(): string {
 }
 
 function getComposeSourceMapsPath(): string {
-  // detect if compose-source-maps.js script exists
+  // check if `compose-source-maps.js` exists
   const composeSourceMapsPath = path.join("node_modules", "react-native", "scripts", "compose-source-maps.js");
   if (fs.existsSync(composeSourceMapsPath)) {
-      return composeSourceMapsPath;
+    return composeSourceMapsPath;
   }
   return null;
 }


### PR DESCRIPTION
When react-native executes the`bundle` command, if `--sourcemap-output` is selected, `index.android.bundle.packager.map` and `index.android.bundle.compiler.map` are used to generate true `index.android.bundle.map`

But `appcenter-cli` didn't do it, and `index.android.bundle.hbc.map` will also be included in the push.

[https://github.com/facebook/react-native/blob/master/react.gradle#L211](https://github.com/facebook/react-native/blob/master/react.gradle#L211)