### PR TITLE
loadReleaseIdUntilSuccess retries on 500 error response

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -469,7 +469,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
           "x-api-token": accessToken,
         },
       });
-      if (response.status < 200 || response.status > 300) {
+      if (response.status < 200 || response.status >= 300) {
         throw failure(ErrorCodes.Exception, `failed to get release id with HTTP status: ${response.status} - ${response.statusText}`);
       }
       return await response.json();

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -435,7 +435,13 @@ export default class ReleaseBinaryCommand extends AppCommand {
   private async loadReleaseIdUntilSuccess(app: DefaultApp, uploadId: string): Promise<any> {
     return new Promise((resolve, reject) => {
       const timerId = setInterval(async () => {
-        const response = await this.loadReleaseId(app, uploadId);
+        let response;
+        try {
+          response = await this.loadReleaseId(app, uploadId);
+        } catch (error) {
+          clearInterval(timerId);
+          reject(new Error(`Loading release id failed with error: ${error.errorMessage}`));
+        }
         const releaseId = response.release_distinct_id;
         debug(`Received release id is ${releaseId}`);
         if (response.upload_status === "readyToBePublished" && releaseId) {
@@ -463,6 +469,9 @@ export default class ReleaseBinaryCommand extends AppCommand {
           "x-api-token": accessToken,
         },
       });
+      if (response.status < 200 || response.status > 300) {
+        throw failure(ErrorCodes.Exception, `failed to get release id with HTTP status: ${response.status} - ${response.statusText}`);
+      }
       return await response.json();
     } catch (error) {
       throw failure(ErrorCodes.Exception, `failed to get release id for upload id: ${uploadId}, error: ${JSON.stringify(error)}`);

--- a/test/commands/distribute/release/release-test.ts
+++ b/test/commands/distribute/release/release-test.ts
@@ -472,7 +472,7 @@ describe("release command", () => {
       );
     });
 
-    it("should fail during get release when HTTP status isn't 200", async () => {
+    it("should fail during get release when HTTP status isn't 2xx", async () => {
       // Arrange
       const releaseFilePath = createFile(tmpFolderPath, releaseFileName, releaseFileContent);
 


### PR DESCRIPTION
Add a check for the status code of the response and process it accordingly to avoid retrying when receiving error response.