### PR TITLE
Add a flag for settng the project name when running "release-react"

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -32,12 +32,14 @@ interface XCBuildConfiguration {
 
 export async function getReactNativeProjectAppVersion(
   versionSearchParams: VersionSearchParams,
-  projectRoot?: string
+  projectName?: string
 ): Promise<string> {
-  projectRoot = projectRoot || process.cwd();
-  // eslint-disable-next-line security/detect-non-literal-require
-  const projectPackageJson: any = require(path.join(projectRoot, "package.json"));
-  const projectName: string = projectPackageJson.name;
+  if (!projectName) {
+    const projectRoot = process.cwd();
+    // eslint-disable-next-line security/detect-non-literal-require
+    const projectPackageJson: any = require(path.join(projectRoot, "package.json"));
+    projectName = projectPackageJson.name;
+  }
 
   const fileExists = (file: string): boolean => {
     try {

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -105,7 +105,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @hasArg
   public extraHermesFlags: string | string[];
 
-  @help("Override the name of the project instead of using the ne from package.json")
+  @help("Override the name of the project instead of using the name from package.json")
   @longName("project-name")
   @hasArg
   public projectName: string;

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -105,6 +105,11 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @hasArg
   public extraHermesFlags: string | string[];
 
+  @help("Override the name of the project instead of using the ne from package.json")
+  @longName("project-name")
+  @hasArg
+  public projectName: string;
+
   private os: string;
 
   private platform: string;
@@ -184,7 +189,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
         gradleFile: this.gradleFile,
         buildConfigurationName: this.buildConfigurationName,
       } as VersionSearchParams;
-      this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
+      this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams, this.projectName);
     }
 
     if (typeof this.extraBundlerOptions === "string") {


### PR DESCRIPTION
This is needed when you want to make use of the logic to automatically detect the current iOS version, but the `package.json`'s `name` does not match the name of the iOS project path. This is common in monorepo setups where it might be called something like `mobile-app`.

This PR adds a new argument for the command allowing you to manually set the project name. It still uses all of the same logic for finding the version.

I have also removed the `projectRoot` argument for the `getReactNativeProjectAppVersion` as it was unused and was always `undefined` whenever the function was called.