### PR TITLE
Test appcenter-file-upload-client-node package in build pipeline

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -321,6 +321,12 @@
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/chokidar/-/chokidar-3.3.0.tgz",
@@ -435,6 +441,12 @@
           "dev": true
         }
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -1190,6 +1202,25 @@
       "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1303,6 +1334,51 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.0.tgz",
+      "integrity": "sha512-20HoWh2HEfhqmigfXOKUhZQyX23JImskc37ZOhIjBKoBEsb+4cAFRJpAVhFpnvsztLklW/gFVzsrobjLwmX4lA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^4.0.0",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2076,6 +2152,12 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -13,6 +13,7 @@
     "build": "npm run lint && npm run build:tsc",
     "build:tsc": "tsc --project tsconfig.json",
     "test": "npm run build && npm run mocha-tests",
+    "test:ci": "node_modules/mocha/bin/mocha --require ts-node/register --reporter mocha-junit-reporter ./tests/**/*-tests.[tj]s --timeout 4000",
     "mocha-tests": "node_modules/mocha/bin/mocha 'out/tests/unit/**/*tests.js'",
     "lint": "eslint \"src/**/*.ts\"",
     "lint-fix": "eslint \"src/**/*.ts\" --fix"
@@ -29,6 +30,7 @@
     "eslint-plugin-prettier": "3.1.3",
     "eslint-plugin-security": "1.4.0",
     "mocha": "7.1.1",
+    "mocha-junit-reporter": "2.0.0",
     "nock": "^13.0.2",
     "prettier": "2.0.4",
     "ts-node": "8.9.1",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,13 @@ jobs:
   - script: |
       npm ci
       npm run build
-    displayName: 'Install and build'
+    displayName: 'Install and build CLI'
+
+  - script: |
+      npm ci
+      npm run build
+    displayName: 'Install and build appcenter-file-upload-client-node'
+    workingDirectory: appcenter-file-upload-client-node
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance (PR)
@@ -40,7 +46,7 @@ jobs:
 
   - script: |
       npm run test:ci || [ -f './test-results.xml' ]
-    displayName: 'Run tests (with JUnit output)'
+    displayName: 'Run CLI tests (with JUnit output)'
 
   - task: PublishTestResults@2
     inputs:
@@ -48,8 +54,22 @@ jobs:
       testResultsFiles: 'test-results.xml'
       searchFolder: '$(Build.SourcesDirectory)'
       failTaskOnFailedTests: true
-      testRunTitle: 'Verify unit test result'
-    displayName: 'Verify unit test result'
+      testRunTitle: 'Verify CLI unit test result'
+    displayName: 'Verify CLI unit test result'
+
+  - script: |
+      npm run test:ci || [ -f './test-results.xml' ]
+    displayName: 'Run appcenter-file-upload-client-node tests'
+    workingDirectory: appcenter-file-upload-client-node
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'test-results.xml'
+      searchFolder: '$(Build.SourcesDirectory)/appcenter-file-upload-client-node'
+      failTaskOnFailedTests: true
+      testRunTitle: 'Verify appcenter-file-upload-client-node unit test result'
+    displayName: 'Verify appcenter-file-upload-client-node unit test result'
 
   - task: AzureKeyVault@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,13 +17,7 @@ jobs:
   - script: |
       npm ci
       npm run build
-    displayName: 'Install and build CLI'
-
-  - script: |
-      npm ci
-      npm run build
-    displayName: 'Install and build appcenter-file-upload-client-node'
-    workingDirectory: appcenter-file-upload-client-node
+    displayName: 'Install and build'
 
   - task: ComponentGovernanceComponentDetection@0
     displayName: Component Governance (PR)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
       testResultsFiles: 'test-results.xml'
       searchFolder: '$(Build.SourcesDirectory)'
       failTaskOnFailedTests: true
-      testRunTitle: 'Verify CLI unit test result'
+      testRunTitle: 'CLI unit tests'
     displayName: 'Verify CLI unit test result'
 
   - script: |
@@ -62,7 +62,7 @@ jobs:
       testResultsFiles: 'test-results.xml'
       searchFolder: '$(Build.SourcesDirectory)/appcenter-file-upload-client-node'
       failTaskOnFailedTests: true
-      testRunTitle: 'Verify appcenter-file-upload-client-node unit test result'
+      testRunTitle: 'appcenter-file-upload-client-node unit tests'
     displayName: 'Verify appcenter-file-upload-client-node unit test result'
 
   - task: AzureKeyVault@1
@@ -88,7 +88,7 @@ jobs:
       testResultsFiles: 'testresult.xml'
       searchFolder: '$(Build.SourcesDirectory)/test/functional'
       failTaskOnFailedTests: true
-      testRunTitle: 'Verify functional test result'
+      testRunTitle: 'Functional tests'
     displayName: 'Verify functional test result'
 
   - script: |


### PR DESCRIPTION
The appcenter-file-upload-client-node package is already built as part of building the main CLI package.
Now the build pipeline also runs its tests and verifies their running and results.
This adds only a couple of seconds to a pipeline running a couple of minutes. No need to separate things out.