### PR TITLE
Fixes passing token/env into release task from group publish

### DIFF
--- a/src/commands/distribute/groups/publish.ts
+++ b/src/commands/distribute/groups/publish.ts
@@ -65,6 +65,11 @@ export default class PublishToGroupCommand extends AppCommand {
     if (!isNil(this.token)) {
       releaseArgs.push("--token", this.token);
     }
+    if (this.disableTelemetry) {
+      releaseArgs.push("--disable-telemetry");
+    }
+    // --help and --version end the command execution before it even gets here
+    // --debug, --format and --quiet set global variables which remain for the command newly created below
 
     const releaseCommandArgs: CommandArgs = {
       args: releaseArgs,

--- a/src/commands/distribute/groups/publish.ts
+++ b/src/commands/distribute/groups/publish.ts
@@ -59,6 +59,12 @@ export default class PublishToGroupCommand extends AppCommand {
     if (!isNil(this.releaseNotesFile)) {
       releaseArgs.push("--release-notes-file", this.releaseNotesFile);
     }
+    if (!isNil(this.environmentName)) {
+      releaseArgs.push("--env", this.environmentName);
+    }
+    if (!isNil(this.token)) {
+      releaseArgs.push("--token", this.token);
+    }
 
     const releaseCommandArgs: CommandArgs = {
       args: releaseArgs,

--- a/src/commands/distribute/stores/publish.ts
+++ b/src/commands/distribute/stores/publish.ts
@@ -41,6 +41,17 @@ export default class PublishToStoreCommand extends AppCommand {
     if (!isNil(this.releaseNotesFile)) {
       releaseArgs.push("--release-notes-file", this.releaseNotesFile);
     }
+    if (!isNil(this.environmentName)) {
+      releaseArgs.push("--env", this.environmentName);
+    }
+    if (!isNil(this.token)) {
+      releaseArgs.push("--token", this.token);
+    }
+    if (this.disableTelemetry) {
+      releaseArgs.push("--disable-telemetry");
+    }
+    // --help and --version end the command execution before it even gets here
+    // --debug, --format and --quiet set global variables which remain for the command newly created below
 
     const releaseCommandArgs: CommandArgs = {
       args: releaseArgs,

--- a/test/commands/distribute/groups/publish-test.ts
+++ b/test/commands/distribute/groups/publish-test.ts
@@ -72,6 +72,7 @@ describe("distribute groups publish command", () => {
         fakeToken,
         "--env",
         environment,
+        "--disable-telemetry",
       ],
       command: ["distribute", "groups", "publish"],
       commandPath: fakeCommandPath,
@@ -94,6 +95,7 @@ describe("distribute groups publish command", () => {
     expect(releaseCommand.releaseNotesFile).equals(fakeReleaseNotesFile);
     expect(releaseCommand.token).equals(fakeToken);
     expect(releaseCommand.environmentName).equals(environment);
+    expect(releaseCommand.disableTelemetry).to.be.true;
   });
 
   it("returns the return value of 'distribute release'", async () => {

--- a/test/commands/distribute/groups/publish-test.ts
+++ b/test/commands/distribute/groups/publish-test.ts
@@ -18,6 +18,7 @@ describe("distribute groups publish command", () => {
   const fakeReleaseNotesFile = "/fake/release_notes";
   const buildVersion = "123";
   const buildNumber = "1234";
+  const environment = "local";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
   const originalReleaseBinaryCommandPrototype = Object.getPrototypeOf(ReleaseBinaryCommand);
 
@@ -50,10 +51,31 @@ describe("distribute groups publish command", () => {
     Nock.enableNetConnect();
   });
 
-  it("passes all non-common parameters to distribute release", async () => {
-    const command = new PublishToGroupCommand(
-      getCommandArgs(["-b", buildVersion, "-n", buildNumber, "-r", releaseNotes, "-R", fakeReleaseNotesFile])
-    );
+  it("passes all appropriate parameters to distribute release", async () => {
+    const command = new PublishToGroupCommand({
+      args: [
+        "-a",
+        fakeAppIdentifier,
+        "-f",
+        fakeFilePath,
+        "-g",
+        fakeGroupName,
+        "-b",
+        buildVersion,
+        "-n",
+        buildNumber,
+        "-r",
+        releaseNotes,
+        "-R",
+        fakeReleaseNotesFile,
+        "--token",
+        fakeToken,
+        "--env",
+        environment,
+      ],
+      command: ["distribute", "groups", "publish"],
+      commandPath: fakeCommandPath,
+    });
     await command.execute();
 
     // Make sure it created a ReleaseBinaryCommand and ran it
@@ -70,6 +92,8 @@ describe("distribute groups publish command", () => {
     expect(releaseCommand.storeName).to.be.undefined;
     expect(releaseCommand.releaseNotes).equals(releaseNotes);
     expect(releaseCommand.releaseNotesFile).equals(fakeReleaseNotesFile);
+    expect(releaseCommand.token).equals(fakeToken);
+    expect(releaseCommand.environmentName).equals(environment);
   });
 
   it("returns the return value of 'distribute release'", async () => {

--- a/test/commands/distribute/stores/publish-test.ts
+++ b/test/commands/distribute/stores/publish-test.ts
@@ -17,6 +17,7 @@ describe("distribute stores publish command", () => {
   const releaseNotes = "Fake release";
   const fakeReleaseNotesFile = "/fake/release_notes";
   const fakeCommandPath = "fake/distribute/groups/publish.ts";
+  const environment = "local";
 
   let sandbox: Sinon.SinonSandbox;
   let createReleaseStub: Sinon.SinonStub;
@@ -46,8 +47,8 @@ describe("distribute stores publish command", () => {
     Nock.enableNetConnect();
   });
 
-  it("passes all non-common parameters to distribute release", async () => {
-    const command = new PublishToStoreCommand(getCommandArgs(["-r", releaseNotes, "-R", fakeReleaseNotesFile]));
+  it("passes all appropriate parameters to distribute release", async () => {
+    const command = new PublishToStoreCommand(getCommandArgs(["-r", releaseNotes, "-R", fakeReleaseNotesFile, "--disable-telemetry"]));
     await command.execute();
 
     // Make sure it created a ReleaseBinaryCommand and ran it
@@ -62,6 +63,9 @@ describe("distribute stores publish command", () => {
     expect(releaseCommand.storeName).equals(fakeStoreName);
     expect(releaseCommand.releaseNotes).equals(releaseNotes);
     expect(releaseCommand.releaseNotesFile).equals(fakeReleaseNotesFile);
+    expect(releaseCommand.token).equals(fakeToken);
+    expect(releaseCommand.environmentName).equals(environment);
+    expect(releaseCommand.disableTelemetry).to.be.true;
   });
 
   it("returns the return value of 'distribute release'", async () => {
@@ -83,7 +87,7 @@ describe("distribute stores publish command", () => {
       "--token",
       fakeToken,
       "--env",
-      "local",
+      environment,
     ].concat(additionalArgs);
     return {
       args,


### PR DESCRIPTION
Fixes in issue where `distribute release` with `--token` works but `distribute groups publish` does not (with a 403) due to not forwarding params from the groups/publish task.