### PR TITLE
[CodePush] Fix Hermes path for new version

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as xml2js from "xml2js";
 import { out, isDebug } from "../../../util/interaction";
-import { isValidVersion } from "./validation-utils";
+import { isValidVersion, isLowVersion } from "./validation-utils";
 import { fileDoesNotExistOrIsDirectory } from "./file-utils";
 import * as chalk from "chalk";
 
@@ -443,7 +443,7 @@ function getHermesOSExe(): string {
     case "win32":
       return "hermes.exe";
     default:
-      return "hermes";
+      return isLowVersion(getReactNativeVersion(), "0.63.0") ? "hermes" : "hermesc";
   }
 }
 
@@ -486,7 +486,7 @@ export function isValidPlatform(platform: string): boolean {
   return platform.toLowerCase() === "react-native";
 }
 
-export function isReactNativeProject(): boolean {
+export function getReactNativeVersion(): string {
   try {
     // eslint-disable-next-line security/detect-non-literal-require
     const projectPackageJson: any = require(path.join(process.cwd(), "package.json"));

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -439,11 +439,12 @@ function getHermesOSBin(): string {
 }
 
 function getHermesOSExe(): string {
+  const hermesExecutableName = isLowVersion(getReactNativeVersion(), "0.63.0") ? "hermes" : "hermesc";
   switch (process.platform) {
     case "win32":
-      return "hermes.exe";
+      return hermesExecutableName + ".exe";
     default:
-      return isLowVersion(getReactNativeVersion(), "0.63.0") ? "hermes" : "hermesc";
+      return hermesExecutableName;
   }
 }
 

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -20,6 +20,10 @@ export function isValidRollout(rollout: number): boolean {
   return rollout && rollout > 0 && rollout <= 100;
 }
 
+export function isLowVersion(v1: string, v2: string): boolean {
+  return semver.compare(v1, v2) === -1 ? true : false;
+}
+
 export async function isValidDeployment(client: AppCenterClient, app: DefaultApp, deploymentName: string): Promise<boolean> {
   const httpRequest = await clientRequest<models.CodePushRelease>((cb) =>
     client.codePushDeployments.get(deploymentName, app.ownerName, app.appName, cb)

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -16,7 +16,7 @@ import {
   getHermesEnabled,
   isValidOS,
   isValidPlatform,
-  isReactNativeProject,
+  getReactNativeVersion,
 } from "./lib/react-native-utils";
 import * as chalk from "chalk";
 
@@ -110,7 +110,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   private platform: string;
 
   public async run(client: AppCenterClient): Promise<CommandResult> {
-    if (!isReactNativeProject()) {
+    if (!getReactNativeVersion()) {
       return failure(ErrorCodes.InvalidParameter, "The project in the CWD is not a React Native project.");
     }
 


### PR DESCRIPTION
**Issue:**  Hermes path, it changed in the RN 0.63 release (because they upgraded Hermes from 0.4.0 to 0.5.0).

**Solution:** Update path for new versions.

**Related issue:** #1017 [#1886](https://github.com/microsoft/react-native-code-push/issues/1886)
