### PR TITLE
Version number to 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
The changes since the last version number bump include the new attempt at turning the mcfus code into a truly external npm package, although the code is still in this repo. The rest of the changes are dependency updates.