### PR TITLE
Make appcenter-cli debugging easier

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,10 +33,10 @@
       },
       "console": "internalConsole",
       "outFiles": []
-    },
+    },    
     {
       "name": "Launch with sourcemaps",
-      "type": "node2",
+      "type": "node",
       "console": "integratedTerminal",
       "request": "launch",
       "program": "${workspaceRoot}/src/index.ts",
@@ -45,17 +45,36 @@
         "--nolazy"
       ],
       "args": [
-        // Add your Mobile Center CLI command
+        // Add your App Center CLI command
       ],
       "outFiles": [
         "${workspaceRoot}/dist/**/*.js"
       ],
       "sourceMaps": true,
       "preLaunchTask": "build-sourcemaps"
+    }, 
+    // Debugger when sourcemaps don't need to be built again
+    {
+      "name": "Launch without building sourcemaps",
+      "type": "node",
+      "console": "integratedTerminal",
+      "request": "launch",
+      "program": "${workspaceRoot}/src/index.ts",
+      "cwd": "${workspaceRoot}",
+      "runtimeArgs": [
+        "--nolazy"
+      ],
+      "args": [
+       // Add your App Center CLI command
+      ],
+      "outFiles": [
+        "${workspaceRoot}/dist/**/*.js"
+      ],
+      "sourceMaps": true
     },
     {
       "name": "Attach",
-      "type": "node2",
+      "type": "node",
       "request": "attach",
       "port": 5858,
       "address": "localhost",
@@ -67,7 +86,7 @@
     },
     {
       "name": "Attach to Process",
-      "type": "node2",
+      "type": "node",
       "request": "attach",
       "processId": "${command.PickProcess}",
       "port": 5858,

--- a/contributing.md
+++ b/contributing.md
@@ -117,6 +117,7 @@ There are a bunch of scripts in package.json file. Here's what they are and what
 | `npm run clean`      | Cleans up any compilation output                                                       |
 | `npm run autorest`   | Regenerate the HTTP client libraries. Downloads required tools as part of this process |
 | `npm run lint`       | Runs the linter over the codebase                                                      |
+| `npm run compile`    | Compiles the typescript into javasctipy, creates `dist` directory                      |
 
 There will be more over time.
 
@@ -136,6 +137,15 @@ The gulpfile.js file contains the following targets that can be called manually 
 | `copy-assets`           |              | Copies .txt files from src to dist (category descriptions)              |
 | `copy-generated-client` |              | Copies the generated HTTP client code to dist                           |
 | `prepublish`            | `prepublish` | Runs the `clean` and `build:raw` tasks before publishing to npm         |
+
+## Debugger
+
+Debugging configurations are stored in launch.json file. Here're what they are and what they do:
+
+| Target                              | What it does                                                                     |
+| ------------------------------------| -------------------------------------------------------------------------------- |
+| `Launch with sourcemaps`            | Build sourcemaps, attach a debugger when testing an App Center CLI command       |
+| `Launch without building sourcemaps`| Attach a debugger when testing an App Center CLI command                         |
 
 ## Touring the codebase
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "build": "npm run lint && gulp build:raw",
+    "build": "npm run lint && npm run compile",
     "lint": "eslint \"bin/**/*.js\" \"src/**/*.ts\" \"scripts/**/*.js\" \"test/**/*.ts\"",
     "lint-fix": "npm run lint -- --fix",
     "test": "npm run lint && mocha --require ts-node/register ./test/**/*-test.[tj]s --timeout 4000",
@@ -28,6 +28,7 @@
     "autorest": "npm run autorest:clean && node scripts/autorest.js",
     "autorest:gen": "node --max-old-space-size=16384 node_modules/autorest/dist/app.js --debug swagger/readme.md",
     "clean": "gulp clean",
+    "compile": "gulp build:raw",
     "prepublishOnly": "npm run lint && gulp prepublish",
     "download-swagger": "gulp download-swagger",
     "prettier": "prettier --write \"**/*.+(js|ts)\""


### PR DESCRIPTION
**Updates**
1. `npm run build` runs the linter every time wasting time when debugging. So, created `npm run compile` to use it when debugging.
2. `node2` is outdated, so updated it to `node`.  
3. Add a section to explain how to use debugging configurations defined in `launch.json` in the contribuding.md. 
4. Created a new debugging config, `Launch without building sourcemaps` to use when there's no change in source code. It reduces time to build sourcemaps as it's not necessary.  