### PR TITLE
Add proxy variables support to fetch calls in the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "abort-controller": "^3.0.0",
-    "appcenter-file-upload-client-node": "1.0.0",
+    "appcenter-file-upload-client-node": "1.1.0",
     "appcenter-file-upload-client": "0.0.24",
     "azure-storage": "2.10.3",
     "bplist": "0.0.4",

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -30,9 +30,9 @@ import {
   LogProperties,
   IUploadStats,
   IInitializeSettings,
+  fetchWithOptions,
 } from "appcenter-file-upload-client-node";
 import { environments } from "../../util/profile/environments";
-import fetch from "node-fetch";
 
 const debug = require("debug")("appcenter-cli:commands:distribute:release");
 
@@ -363,7 +363,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const accessToken = await this.getToken(profile);
     const url = getFileUploadLink(endpoint, app.ownerName, app.appName);
     const body = JSON.stringify({ build_version: this.buildVersion, build_number: this.buildNumber });
-    const response = await fetch(url, {
+    const response = await fetchWithOptions(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -416,7 +416,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
     const endpoint = await this.getEndpoint(profile);
     const accessToken = await this.getToken(profile);
     const url = getPatchUploadLink(endpoint, app.ownerName, app.appName, uploadId);
-    const response = await fetch(url, {
+    const response = await fetchWithOptions(url, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -464,7 +464,7 @@ export default class ReleaseBinaryCommand extends AppCommand {
       const endpoint = await this.getEndpoint(profile);
       const accessToken = await this.getToken(profile);
       const url = getPatchUploadLink(endpoint, app.ownerName, app.appName, uploadId);
-      const response = await fetch(url, {
+      const response = await fetchWithOptions(url, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
This PR updates **appcenter-file-upload-client-node** dependency and applies the new 'fetchWithOptions' method from https://github.com/microsoft/appcenter-cli/pull/1044.
It should be merged after the **appcenter-file-upload-client-node** is updated to 1.1.0 in the npm registry.

Related work items:
Original issue: #982
[AB#81897](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/IvanM-Team/Backlog%20Items/?workitem=81897)