### PR TITLE
Open PRs for all dependency updates (not just five)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     # Check the npm registry for updates every weekday
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20
   # Enable version updates for npm on the inner appcenter-file-upload-client-node package
   - package-ecosystem: "npm"
     directory: "/appcenter-file-upload-client-node"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
This would explain why we still have many outdated dependencies, and fix that.