### PR TITLE
[code-push] [release-react] fix version with caret and react-native custom build

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -1,10 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as xml2js from "xml2js";
-import * as semver from "semver";
 import { out, isDebug } from "../../../util/interaction";
 import { isValidVersion } from "./validation-utils";
 import { fileDoesNotExistOrIsDirectory } from "./file-utils";
+import { coerce, compare } from "semver";
 import * as chalk from "chalk";
 
 const xcode = require("xcode");
@@ -440,7 +440,8 @@ function getHermesOSBin(): string {
 }
 
 function getHermesOSExe(): string {
-  const hermesExecutableName = semver.compare(semver.coerce(getReactNativeVersion()).version, "0.63.0") === -1 ? "hermes" : "hermesc";
+  const react63orAbove = compare(coerce(getReactNativeVersion()).version, "0.63.0") !== -1;
+  const hermesExecutableName = react63orAbove ? "hermesc" : "hermes";
   switch (process.platform) {
     case "win32":
       return hermesExecutableName + ".exe";

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -1,8 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as xml2js from "xml2js";
+import * as semver from "semver";
 import { out, isDebug } from "../../../util/interaction";
-import { isValidVersion, isLowVersion } from "./validation-utils";
+import { isValidVersion } from "./validation-utils";
 import { fileDoesNotExistOrIsDirectory } from "./file-utils";
 import * as chalk from "chalk";
 
@@ -439,7 +440,7 @@ function getHermesOSBin(): string {
 }
 
 function getHermesOSExe(): string {
-  const hermesExecutableName = isLowVersion(getReactNativeVersion(), "0.63.0") ? "hermes" : "hermesc";
+  const hermesExecutableName = semver.compare(semver.coerce(getReactNativeVersion()).version, "0.63.0") === -1 ? "hermes" : "hermesc";
   switch (process.platform) {
     case "win32":
       return hermesExecutableName + ".exe";

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -21,7 +21,7 @@ export function isValidRollout(rollout: number): boolean {
 }
 
 export function isLowVersion(v1: string, v2: string): boolean {
-  return semver.compare(v1, v2) === -1 ? true : false;
+  return semver.compare(semver.coerce(v1).version, v2) === -1;
 }
 
 export async function isValidDeployment(client: AppCenterClient, app: DefaultApp, deploymentName: string): Promise<boolean> {

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -1,3 +1,4 @@
+import * as semver from "semver";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 

--- a/src/commands/codepush/lib/validation-utils.ts
+++ b/src/commands/codepush/lib/validation-utils.ts
@@ -1,4 +1,3 @@
-import * as semver from "semver";
 import { AppCenterClient, models, clientRequest } from "../../../util/apis";
 import { DefaultApp } from "../../../util/profile";
 
@@ -18,10 +17,6 @@ export function isValidRange(semverRange: string): boolean {
 
 export function isValidRollout(rollout: number): boolean {
   return rollout && rollout > 0 && rollout <= 100;
-}
-
-export function isLowVersion(v1: string, v2: string): boolean {
-  return semver.compare(semver.coerce(v1).version, v2) === -1;
 }
 
 export async function isValidDeployment(client: AppCenterClient, app: DefaultApp, deploymentName: string): Promise<boolean> {


### PR DESCRIPTION
This fix resolves these issues:
https://github.com/microsoft/react-native-code-push/issues/1676
https://github.com/microsoft/react-native-code-push/issues/1939

I've used `semver.coerce()` to clear version string. Now `mobiletechvn/react-native#v0.63.2.fix-shadow-node` or `^0.63.2` will transform into `0.63.2`. And Hermes version will be checked correctly.