### PR TITLE
[CodePush] Cancel release for failed bundle

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -321,7 +321,6 @@ export function runReactNativeBundleCommand(
     });
 
     reactNativeBundleProcess.stderr.on("data", (data: Buffer) => {
-      console.error(data.toString().trim());
       reject(new Error(`"react-native bundle" command failed: ${data.toString().trim()}`));
     });
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -322,6 +322,7 @@ export function runReactNativeBundleCommand(
 
     reactNativeBundleProcess.stderr.on("data", (data: Buffer) => {
       console.error(data.toString().trim());
+      reject(new Error(`"react-native bundle" command failed: ${data.toString().trim()}`));
     });
 
     reactNativeBundleProcess.on("close", (exitCode: number) => {


### PR DESCRIPTION
**Issue**: appcenter-cli creates release when React Native bundling is failed
**Related issue**: #911 
**Solution**: Reject release process when React Native bundling is failed