### PR TITLE
[CodePush] Add limit for request

### DIFF
--- a/src/util/misc/promise-map.ts
+++ b/src/util/misc/promise-map.ts
@@ -1,0 +1,25 @@
+export async function promiseMap<T, U>(items: T[], mapper: (item: T) => Promise<U>, concurrency: number = Infinity): Promise<U[]> {
+  if (!items || !mapper) {
+    throw new Error("items array and action must be defined");
+  }
+
+  if (items.length <= concurrency) {
+    return Promise.all(items.map((item) => mapper(item)));
+  }
+
+  const inProgress = new Set<Promise<U>>();
+  const results: Promise<U>[] = [];
+  for (const item of items) {
+    if (inProgress.size >= concurrency) {
+      await Promise.race(inProgress);
+    }
+
+    const itemPromise = mapper(item);
+    inProgress.add(itemPromise);
+    results.push(itemPromise);
+
+    itemPromise.finally(() => inProgress.delete(itemPromise));
+  }
+
+  return Promise.all(results);
+}


### PR DESCRIPTION
**Issue**: `deployment list` command gets the list of the deployments (which works flawlessly as this is one request) and then for each deployment tries to get metrics info if `latest_release` field of the deployment is not empty by sending request-per-deployment simultaneously. The server in that case returns 429 error "Too many requests".

**Solution**: Limit the number of requests per time.