### PR TITLE
Add logs to the distribute functional tests

### DIFF
--- a/test/functional/commands/distribute/Release.Tests.ps1
+++ b/test/functional/commands/distribute/Release.Tests.ps1
@@ -4,7 +4,9 @@ Describe "distribute release" {
     $appDisplayName = "TestDistributeRelease$((Get-Date).ToString("yyyy-MM-dd_HH.mm.ffffff"))"
     $appOs = "Custom"
     $appPlatform = "Custom"
-    $app = appcenter apps create --platform $appPlatform --os $appOs --display-name $appDisplayName --output json | ConvertFrom-Json
+    $createOutput = appcenter apps create --platform $appPlatform --os $appOs --display-name $appDisplayName --output json
+    Write-Host "apps create output: $createOutput"
+    $app = $createOutput | ConvertFrom-Json
     $appFullName = $app.owner.name + "/" + $app.name
     appcenter apps set-current $appFullName
 
@@ -13,10 +15,14 @@ Describe "distribute release" {
     [io.file]::Create($filename).SetLength(1024 * 1024 * 10).Close
 
     # Act
-    $r1 = appcenter distribute release -g Collaborators -f $fileName --build-version 1 --mandatory --output json | ConvertFrom-Json
+    $distributeReleaseOutput = appcenter distribute release -g Collaborators -f $fileName --build-version 1 --mandatory --output json
+    Write-Host "distribute release output: $distributeReleaseOutput"
+    $r1 = $distributeReleaseOutput | ConvertFrom-Json
 
     # Assert
-    $group = appcenter distribute groups show -g Collaborators --output json | ConvertFrom-Json
+    $groupsShowOutput = appcenter distribute groups show -g Collaborators --output json
+    Write-Host "distribute groups show output: $groupsShowOutput"
+    $group = $groupsShowOutput | ConvertFrom-Json
     $r2 = $group[1].tables | Where-Object {$_.id -eq $r1.id}
     $r2.mandatoryUpdate | Should -Be "True"
 


### PR DESCRIPTION
The distribute functional tests are flaky at the moment. Sometimes the [tests fail](https://msmobilecenter.visualstudio.com/Mobile-Center/_build/results?buildId=1004359&view=logs&j=50448a2f-9550-51a0-b6c4-5ec64224dd81&t=14e66476-54b5-552b-93fd-083932f3d78f&s=b15d9194-8f26-5328-b47f-5968c76b37e7) with the following message:
```
Error message

Conversion from JSON failed with error: Unexpected character encountered while parsing value: E. Path '', line 0, position 0.

Stack trace

at <ScriptBlock>, /home/vsts/work/1/s/test/functional/commands/distribute/Release.Tests.ps1: line 16 16: $r1 = appcenter distribute release -g Collaborators -f $fileName --build-version 1 --mandatory --output json | ConvertFrom-Json
```

Additional logging will help us narrow down the problem.
[AB#84621](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=84621)