### PR TITLE
Add GitHub issue template for bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - `appcenter-cli` version: [e.g. 2.7.3]
+ - `OS`: [e.g. macOS]
+ - `react-native-code-push` version [e.g. 7.0.0]
+ - Node.js version: [e.g. 14.7.0]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Hello 👋🏼 

Recently I opened an issue on the repository and I forgot to set a lot of details that were interesting such as version numbers and details about the environment.

This could be improved by adding a `bug-report` [GitHub Issue Template](https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository) that act as a "placeholder" for the user before creating an issue,

So when the user clicks on "New issue" button It'll see something like this:

![Screenshot 2021-01-29 at 12 44 13](https://user-images.githubusercontent.com/7629661/106272708-c4d2c900-6231-11eb-9f40-794cfdec3c94.png)

![Screenshot 2021-01-29 at 12 45 16](https://user-images.githubusercontent.com/7629661/106272710-c56b5f80-6231-11eb-9745-e4d3cd634746.png)

