### PR TITLE
[CodePush] Fix release issue

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -419,7 +419,7 @@ export function getHermesEnabled(gradleFile: string): boolean {
       throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
     })
     .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"]).includes("enableHermes: true");
+      return Array.from(buildGradle["project.ext.react"] || []).includes("enableHermes: true");
     });
 }
 


### PR DESCRIPTION
**Issues:**
 https://github.com/microsoft/appcenter-cli/issues/1249
https://github.com/microsoft/appcenter-cli/issues/634
https://github.com/microsoft/appcenter-cli/issues/1138

Android codepush release command fails when running:
`return Array.from(buildGradle["project.ext.react"]).includes("enableHermes: true");` because the `buildGradle["project.ext.react"] ` may not exist in build.gradle file.