### PR TITLE
Fix json output for an error

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -562,16 +562,12 @@ export default class ReleaseBinaryCommand extends AppCommand {
       const statusCode = response.statusCode;
       if (statusCode >= 400) {
         debug(`Got error response: ${inspect(response)}`);
-        throw statusCode;
+        throw result;
       }
       return result;
     } catch (error) {
-      if (error === 400) {
-        throw failure(ErrorCodes.Exception, "failed to set the release notes");
-      } else {
-        debug(`Failed to distribute the release - ${inspect(error)}`);
-        throw failure(ErrorCodes.Exception, `failed to set release notes for release ${releaseId}`);
-      }
+      debug(`Failed to set the release notes - ${inspect(error)}`);
+      throw failure(ErrorCodes.Exception, error.message);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { CommandResult, failed, runner as commandRunner } from "./util/commandline";
+import { formatIsJson } from "./util/interaction/io-options";
 
 import * as path from "path";
 import * as chalk from "chalk";
@@ -6,7 +7,11 @@ import * as chalk from "chalk";
 const runner = commandRunner(path.join(__dirname, "commands"));
 runner(process.argv.slice(2)).then((result: CommandResult) => {
   if (failed(result)) {
-    console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+    if (formatIsJson()) {
+      console.log(`${chalk.red("Error:")} ${JSON.stringify(result)}`);
+    } else {
+      console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+    }
     process.exit(result.errorCode);
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const runner = commandRunner(path.join(__dirname, "commands"));
 runner(process.argv.slice(2)).then((result: CommandResult) => {
   if (failed(result)) {
     if (formatIsJson()) {
-      console.log(`${chalk.red("Error:")} ${JSON.stringify(result)}`);
+      console.log(`${chalk.red(JSON.stringify(result))}`);
     } else {
       console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
     }

--- a/test/functional/commands/distribute/Release.Tests.ps1
+++ b/test/functional/commands/distribute/Release.Tests.ps1
@@ -7,6 +7,7 @@ Describe "distribute release" {
     $createOutput = appcenter apps create --platform $appPlatform --os $appOs --display-name $appDisplayName --output json
     Write-Host "apps create output: $createOutput"
     $app = $createOutput | ConvertFrom-Json
+    $app.succeeded | Should -Not -Be $false
     $appFullName = $app.owner.name + "/" + $app.name
     appcenter apps set-current $appFullName
 
@@ -18,13 +19,15 @@ Describe "distribute release" {
     $distributeReleaseOutput = appcenter distribute release -g Collaborators -f $fileName --build-version 1 --mandatory --output json
     Write-Host "distribute release output: $distributeReleaseOutput"
     $r1 = $distributeReleaseOutput | ConvertFrom-Json
+    $r1.succeeded | Should -Not -Be $false
 
     # Assert
     $groupsShowOutput = appcenter distribute groups show -g Collaborators --output json
     Write-Host "distribute groups show output: $groupsShowOutput"
     $group = $groupsShowOutput | ConvertFrom-Json
+    $group.succeeded | Should -Not -Be $false
     $r2 = $group[1].tables | Where-Object {$_.id -eq $r1.id}
-    $r2.mandatoryUpdate | Should -Be "True"
+    $r2.mandatoryUpdate | Should -Be $true
 
     Remove-Item $fileName
 


### PR DESCRIPTION
This PR fixes an output when an error occurs and `--output json` has been specified.

Before:
```
appcenter distribute release -f release.apk --output json
Error: At least one of '--group' or '--store' must be specified
```

After:
```
appcenter distribute release -f release.apk --output json
{"succeeded":false,"errorCode":4,"errorMessage":"At least one of '--group' or '--store' must be specified"}
```

Aside from that it:
- improves the Distribute functional test
- fixes Distribute release notes error message

Related issues:
https://github.com/microsoft/appcenter-cli/issues/1207
https://github.com/microsoft/appcenter-cli/issues/768
[AB#84915](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=84915)