### PR TITLE
CodePush Cordova: Enhance error handling for config.xml parsing

### DIFF
--- a/src/commands/codepush/lib/cordova-utils.ts
+++ b/src/commands/codepush/lib/cordova-utils.ts
@@ -19,7 +19,7 @@ export function getCordovaProjectAppVersion(projectRoot?: string): Promise<strin
 
     xml2js.parseString(configString, (err: Error, parsedConfig: any) => {
       if (err || !parsedConfig || !parsedConfig.widget) {
-        reject(new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid XML.`));
+        reject(new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid.`));
       }
 
       const config: any = parsedConfig.widget;

--- a/src/commands/codepush/lib/cordova-utils.ts
+++ b/src/commands/codepush/lib/cordova-utils.ts
@@ -18,7 +18,7 @@ export function getCordovaProjectAppVersion(projectRoot?: string): Promise<strin
     }
 
     xml2js.parseString(configString, (err: Error, parsedConfig: any) => {
-      if (err) {
+      if (err || !parsedConfig || !parsedConfig.widget) {
         reject(new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid XML.`));
       }
 


### PR DESCRIPTION
Enhance error handling for cordova config.xml parsing.

If config.xml is empty or missing the expected `<widget/>` tag, the errors were unclear.

Before:

`Command Failure at TypeError: Cannot read property '$' of undefined`
`Command Failure at TypeError: Cannot read property 'widget' of null`

After:

`Command Failure at Error: Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid.`
