### PR TITLE
CodePush React: Adds a flag to  specify a custom React Native project name

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -19,6 +19,7 @@ export interface VersionSearchParams {
   plistFilePrefix: string;
   gradleFile: string;
   buildConfigurationName: string;
+  projectName: string;
 }
 
 interface XCBuildConfiguration {
@@ -36,7 +37,11 @@ export async function getReactNativeProjectAppVersion(
   projectRoot = projectRoot || process.cwd();
   // eslint-disable-next-line security/detect-non-literal-require
   const projectPackageJson: any = require(path.join(projectRoot, "package.json"));
-  const projectName: string = projectPackageJson.name;
+  const packageJsonProjectName: string = projectPackageJson.name;
+  const projectName =
+    versionSearchParams.projectName && versionSearchParams.projectName.length
+      ? versionSearchParams.projectName
+      : packageJsonProjectName;
 
   const fileExists = (file: string): boolean => {
     try {

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -105,6 +105,12 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @hasArg
   public extraHermesFlags: string | string[];
 
+  @help("Name used when creating React Native. Should be used if name does not match name in package.json.")
+  @longName("project-name")
+  @shortName("pn")
+  @hasArg
+  public projectName: string;
+
   private os: string;
 
   private platform: string;
@@ -183,6 +189,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
         plistFilePrefix: this.plistFilePrefix,
         gradleFile: this.gradleFile,
         buildConfigurationName: this.buildConfigurationName,
+        projectName: this.projectName,
       } as VersionSearchParams;
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
     }


### PR DESCRIPTION
### Discussion
When creating a React Native project, one can specify a name which becomes the iOS project name. By default this name is saved into `package.json`, and this CLI tool will attempt to read from there to derive the name.

However, it is not uncommon for the `package.json` name to change (e.g. to fit into yarn workspaces).

Therefore, it seems appropriate that a developer would want to change this name and override the automatically discovered name when necessary.

### Solution

Add a flag to the CLI which lets a developer specify the name used when creating a React Native project.

### Example Usage
```sh
> appcenter codepush release-react -a foo/bar --deployment-name Staging -m --description "Foo Bar" --project-name app
```

#### Expected Result:

If the React Native name was `app` when the project was created, the XCode Project will be named `app.xcodeproj`. Thus specifying `--project-name app` will point the CLI to `ios/app.xcodeproj` when building to auto-detect the version.