### PR TITLE
Use the hermesCommand path from build.gradle when running release-react command

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -333,11 +333,12 @@ export function runReactNativeBundleCommand(
   });
 }
 
-export function runHermesEmitBinaryCommand(
+export async function runHermesEmitBinaryCommand(
   bundleName: string,
   outputFolder: string,
   sourcemapOutput: string,
-  extraHermesFlags: string[]
+  extraHermesFlags: string[],
+  gradleFile: string
 ): Promise<void> {
   const hermesArgs: string[] = [];
   const envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
@@ -363,7 +364,7 @@ export function runHermesEmitBinaryCommand(
   }
 
   out.text(chalk.cyan("Converting JS bundle to byte code via Hermes, running command:\n"));
-  const hermesCommand = getHermesCommand();
+  const hermesCommand = await getHermesCommand(gradleFile);
   const hermesProcess = childProcess.spawn(hermesCommand, hermesArgs);
   out.text(`${hermesCommand} ${hermesArgs.join(" ")}`);
 
@@ -400,7 +401,7 @@ export function runHermesEmitBinaryCommand(
   });
 }
 
-export function getHermesEnabled(gradleFile: string): boolean {
+function parseBuildGradleFile(gradleFile: string) {
   let buildGradlePath: string = path.join("android", "app");
   if (gradleFile) {
     buildGradlePath = gradleFile;
@@ -413,14 +414,28 @@ export function getHermesEnabled(gradleFile: string): boolean {
     throw new Error(`Unable to find gradle file "${buildGradlePath}".`);
   }
 
-  return g2js
-    .parseFile(buildGradlePath)
-    .catch(() => {
-      throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
-    })
-    .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"] || []).includes("enableHermes: true");
-    });
+  return g2js.parseFile(buildGradlePath).catch(() => {
+    throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
+  });
+}
+
+export function getHermesEnabled(gradleFile: string): boolean {
+  return parseBuildGradleFile(gradleFile).then((buildGradle: any) => {
+    return Array.from(buildGradle["project.ext.react"] || []).includes("enableHermes: true");
+  });
+}
+
+async function getHermesCommandFromGradle(gradleFile: string): Promise<string> {
+  const buildGradle: any = await parseBuildGradleFile(gradleFile);
+  out.text(buildGradle);
+  const hermesCommandProperty: any = Array.from(buildGradle["project.ext.react"] || []).find((prop: string) =>
+    prop.trim().startsWith("hermesCommand:")
+  );
+  if (hermesCommandProperty) {
+    return hermesCommandProperty.replace("hermesCommand:", "").trim().slice(1, -1);
+  } else {
+    return "";
+  }
 }
 
 function getHermesOSBin(): string {
@@ -448,7 +463,7 @@ function getHermesOSExe(): string {
   }
 }
 
-function getHermesCommand(): string {
+async function getHermesCommand(gradleFile: string): Promise<string> {
   const fileExists = (file: string): boolean => {
     try {
       return fs.statSync(file).isFile();
@@ -456,12 +471,18 @@ function getHermesCommand(): string {
       return false;
     }
   };
-  // assume if hermes-engine exists it should be used instead of hermesvm
-  const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
-  if (fileExists(hermesEngine)) {
-    return hermesEngine;
+
+  const gradleHermesCommand = await getHermesCommandFromGradle(gradleFile);
+  if (gradleHermesCommand) {
+    return path.join("android", "app", gradleHermesCommand.replace("%OS-BIN%", getHermesOSBin()));
+  } else {
+    // assume if hermes-engine exists it should be used instead of hermesvm
+    const hermesEngine = path.join("node_modules", "hermes-engine", getHermesOSBin(), getHermesOSExe());
+    if (fileExists(hermesEngine)) {
+      return hermesEngine;
+    }
+    return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
   }
-  return path.join("node_modules", "hermesvm", getHermesOSBin(), "hermes");
 }
 
 function getCliPath(): string {

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -211,7 +211,13 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
       if (this.os === "android") {
         const isHermesEnabled = await getHermesEnabled(this.gradleFile);
         if (isHermesEnabled) {
-          await runHermesEmitBinaryCommand(this.bundleName, this.updateContentsPath, this.sourcemapOutput, this.extraHermesFlags);
+          await runHermesEmitBinaryCommand(
+            this.bundleName,
+            this.updateContentsPath,
+            this.sourcemapOutput,
+            this.extraHermesFlags,
+            this.gradleFile
+          );
         }
       }
       out.text(chalk.cyan("\nReleasing update contents to CodePush:\n"));


### PR DESCRIPTION
If the `hermesCommand` option is present in `build.gradle` then this path will be used as the path to the hermes executable when running `codepush release-react`

This allows the `release-react` command to be used in monorepos where the `node_modules` directory may be at the root of the monorepo rather then in the project and fixes this issue here: https://github.com/microsoft/appcenter-cli/issues/1170 

Related issue: [#1987](https://github.com/microsoft/appcenter-cli/issues/1987)