### PR TITLE
Fix swallowed error output for access token getter

### DIFF
--- a/src/util/profile/profile.ts
+++ b/src/util/profile/profile.ts
@@ -56,7 +56,14 @@ class ProfileImpl implements Profile {
   }
 
   get accessToken(): Promise<string> {
-    const getter = tokenStore.get(this.userName).catch((err: Error) => tokenStore.get(this.userName, true));
+    const getter = tokenStore.get(this.userName).catch((err: Error) => {
+      debug(`Can't get token from tokenStore: ${err.message}`);
+      if (!err.message.includes("could not be found")) {
+        throw err;
+      }
+      debug(`Fallback to the old name in the keychain.`);
+      return tokenStore.get(this.userName, true);
+    });
 
     return getter
       .then((entry) => entry.accessToken.token)


### PR DESCRIPTION
Context: https://github.com/microsoft/appcenter-cli/issues/1218/

When appcenter cli tries to fetch data from token-store it fallbacks to an old service name ignoring the command error output. It assumes that if the command failed then the service name was not found, so it tries to search for an old service name and then throws an error if there is any. 
However, in this scenario the error message will always be security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
See https://github.com/microsoft/appcenter-cli/blob/master/src/util/profile/profile.ts#L59

We should check what was the error and if it was not a "could not be found" error, then throw it and don't fall back to an old service name.

[AB#85233](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=85233)