### PR TITLE
Node 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ commands that they'd like to execute. You can currently login and view/configure
 
 ## Prerequisites
 
-App Center CLI requires Node.js version 10.
+App Center CLI requires Node.js version 12.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ commands that they'd like to execute. You can currently login and view/configure
 
 ## Prerequisites
 
-App Center CLI requires Node.js version 12.
+The recommended Node.js version is 12 or higher.
 
 ## Installation
 

--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -111,9 +111,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.55.tgz",
-      "integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==",
+      "version": "12.20.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
       "dev": true
     },
     "@types/uuid": {
@@ -361,8 +361,8 @@
     },
     "arg": {
       "version": "4.1.3",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha1-Jp/HrVuOQstjyJbVZmAXJhwUQIk=",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -440,8 +440,8 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "bytes": {
@@ -610,6 +610,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1483,8 +1489,8 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "md5": {
@@ -1720,9 +1726,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha1-5jNFY4bUqlWGP2dqerDaqP3ssP0="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -2165,8 +2171,8 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -2327,12 +2333,13 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "ts-node": {
-      "version": "8.9.1",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/ts-node/-/ts-node-8.9.1.tgz",
-      "integrity": "sha1-L4V/RsR+kdzSihTgUkgusUz9ZaU=",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
@@ -2341,8 +2348,8 @@
       "dependencies": {
         "diff": {
           "version": "4.0.2",
-          "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -2608,8 +2615,8 @@
     },
     "yn": {
       "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -21,7 +21,7 @@
   "main": "out/index.js",
   "devDependencies": {
     "@types/mocha": "8.2.1",
-    "@types/node": "10.x",
+    "@types/node": "12.x",
     "@types/uuid": "7.0.3",
     "@typescript-eslint/eslint-plugin": "4.0.0",
     "@typescript-eslint/parser": "3.10.1",
@@ -33,14 +33,14 @@
     "mocha-junit-reporter": "2.0.0",
     "nock": "13.0.11",
     "prettier": "2.2.1",
-    "ts-node": "8.9.1",
+    "ts-node": "9.1.1",
     "typemoq": "2.1.0",
     "typescript": "3.8.3",
     "uuid": "7.0.3"
   },
   "dependencies": {
     "abort-controller": "3.0.0",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.1",
     "proxy-agent": "3.1.1"
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '12.x'
     displayName: 'Install Node.js'
 
   - script: |

--- a/bin/appcenter.js
+++ b/bin/appcenter.js
@@ -3,7 +3,7 @@
 const util = require("util");
 
 // Verify user has minimum required version of node installed
-const minMajorVersion = 10;
+const minMajorVersion = 12;
 const minMinorVersion = 0;
 
 function getCurrentVersion() {

--- a/bin/appcenter.js
+++ b/bin/appcenter.js
@@ -3,7 +3,7 @@
 const util = require("util");
 
 // Verify user has minimum required version of node installed
-const minMajorVersion = 12;
+const minMajorVersion = 10;
 const minMinorVersion = 0;
 
 function getCurrentVersion() {

--- a/contributing.md
+++ b/contributing.md
@@ -18,7 +18,7 @@ is used to record and playback mock http traffic.
 
 ### Prerequisites
 
-Install the latest version of Node 10 from [here](https://nodejs.org). If you are on a Mac, we recommend
+Install the latest version of Node 12 from [here](https://nodejs.org). If you are on a Mac, we recommend
 a 64-bit version.
 
 Also have a working git installation. The code is available from this [repo](https://github.com/microsoft/appcenter-cli).

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ local CI configurations).
 
 ## Technologies Used
 
-App Center cli is written using Node.js version 10 and [TypeScript](http://typescriptlang.org).
+App Center cli is written using Node.js version 12 and [TypeScript](http://typescriptlang.org).
 Wrappers over the App Center HTTP API are generated using the [AutoRest](https://github.com/Azure/autorest) code generator.
 And the usual plethora of npm modules.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,9 +386,9 @@
       }
     },
     "@types/node": {
-      "version": "10.17.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.55.tgz",
-      "integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==",
+      "version": "12.20.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
+      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -1305,9 +1305,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -7158,20 +7158,13 @@
       }
     },
     "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
+      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
       "requires": {
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
-      },
-      "dependencies": {
-        "xmldom": {
-          "version": "0.1.31",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-          "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-        }
+        "xmldom": "^0.5.0"
       }
     },
     "plugin-error": {
@@ -8027,9 +8020,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-plist": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.0.tgz",
-      "integrity": "sha512-2i5Tc0BYAqppM7jVzmNrI+aEUntPolIq4fDgji6WuNNn1D/qYdn2KwoLhZdzQkE04lu9L5tUoeJsjuJAvd+lFg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.1.tgz",
+      "integrity": "sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==",
       "requires": {
         "bplist-creator": "0.0.8",
         "bplist-parser": "0.2.0",
@@ -9613,9 +9606,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "homepage": "https://github.com/microsoft/appcenter-cli#readme",
   "engine": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "main": "dist/index.js",
   "bin": {
@@ -62,7 +62,7 @@
     "@types/mkdirp": "1.0.1",
     "@types/mocha": "8.2.1",
     "@types/mock-require": "2.0.0",
-    "@types/node": "10.*",
+    "@types/node": "12.*",
     "@types/node-fetch": "2.5.8",
     "@types/opener": "1.4.0",
     "@types/pumpify": "1.4.1",
@@ -130,7 +130,7 @@
     "omelette": "0.4.15",
     "opener": "1.5.2",
     "p-limit": "3.1.0",
-    "plist": "3.0.1",
+    "plist": "3.0.2",
     "properties": "1.2.1",
     "pumpify": "2.0.1",
     "qs": "6.9.6",

--- a/src/util/misc/get-profile-dir.ts
+++ b/src/util/misc/get-profile-dir.ts
@@ -45,20 +45,10 @@ function copyDirSync(srcPath: string, destPath: string): void {
   files
     .map((f: string): [string, string] => [path.join(srcPath, f), path.join(destPath, f)])
     .filter(([src, dest]) => isFileSync(src))
-    .forEach(([src, dest]) => copyFileSync(src, dest));
+    .forEach(([src, dest]) => fs.copyFileSync(src, dest));
 }
 
 function isFileSync(file: string): boolean {
   const stats = fs.statSync(file);
   return stats.isFile();
-}
-
-//
-// fs.copyFileSync is only in very new version of node 8, so implement
-// it locally as compat shim
-//
-function copyFileSync(srcPath: string, destPath: string): void {
-  debug(`Copying file ${srcPath} to ${destPath}`);
-  const contents = fs.readFileSync(srcPath);
-  fs.writeFileSync(destPath, contents);
 }


### PR DESCRIPTION
This PR changes the minimum version of Nodejs to 12 as Node 10 goes out of support in April 2021.

[AB#85969](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/85969)
[AB#85970](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/85970)
[AB#85971](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/85971)