### PR TITLE
Fix entry point error logging

### DIFF
--- a/bin/appcenter.js
+++ b/bin/appcenter.js
@@ -47,7 +47,12 @@ function runCli() {
   runner(args).then(function (result) {
     if (commandLine.failed(result)) {
       const chalk = require("chalk");
-      console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+      const ioOptions = require("../dist/util/interaction/io-options");
+      if (ioOptions.formatIsJson()) {
+        console.log(`${chalk.red(JSON.stringify(result))}`);
+      } else {
+        console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+      }
       process.exit(result.errorCode);
     }
   });


### PR DESCRIPTION
The [previous fix](https://github.com/microsoft/appcenter-cli/pull/1278) was missing the actual entry point fix. Here it is.

This PR fixes an output when an error occurs and `--output json` has been specified.

Before:
```
appcenter distribute release -f release.apk --output json
Error: At least one of '--group' or '--store' must be specified
```

After:
```
appcenter distribute release -f release.apk --output json
{"succeeded":false,"errorCode":4,"errorMessage":"At least one of '--group' or '--store' must be specified"}
```

Related issues:
https://github.com/microsoft/appcenter-cli/issues/1207
https://github.com/microsoft/appcenter-cli/issues/768
[AB#85783](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Ivan-Team/Backlog%20Items/?workitem=85783)