### PR TITLE
Modify condition

### DIFF
--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -82,7 +82,7 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
         if (formatIsJson()) {
           const metricsJSON: models.CodePushReleaseMetric = await this.generateMetricsJSON(deployment, client);
 
-          if (metricsJSON) {
+          if (metricsJSON && deployment.latestRelease) {
             deployment.latestRelease.metrics = metricsJSON;
           }
 

--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -18,7 +18,7 @@ import { promiseMap } from "../../../util/misc/promise-map";
 import { formatDate } from "./lib/date-helper";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:deployments:list");
-const PROMISE_CONCURRENCY = 30;
+const PROMISE_CONCURRENCY = 20;
 
 @help("List the deployments associated with an app")
 export default class CodePushDeploymentListListCommand extends AppCommand {


### PR DESCRIPTION
**Issue**: Now server returns a list of deployments with the `latestRelease` property for and metrics. CLI tries to add the new field `metrics` for the undefined property `latestRelease`.
**Solution**: Add one more condition for checking that the `latestRelease` isn't undefined.