### PR TITLE
Bump appcenter-file-upload-client-node to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -839,9 +839,9 @@
       }
     },
     "appcenter-file-upload-client-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.0.tgz",
-      "integrity": "sha512-kPHYWBg0oqI+6IJVQmG29ErY5QPH8QLd79D+9lniPMyfRXY+cILStf/lRKj9ytQ08ik8/fUquk9WyJjG8ry4tg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.1.tgz",
+      "integrity": "sha512-uyAgXCTu1HrMwfjMEQW3cGIwDGmoqkaarM6lwTUHkcZJdbutaoVBNn0Oaymt/xOTvwjVgvzcMIw5Oz+2c7EB9w==",
       "requires": {
         "abort-controller": "3.0.0",
         "node-fetch": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "abort-controller": "3.0.0",
     "appcenter-file-upload-client": "0.0.24",
-    "appcenter-file-upload-client-node": "1.2.0",
+    "appcenter-file-upload-client-node": "1.2.1",
     "azure-storage": "2.10.3",
     "bplist": "0.0.4",
     "chalk": "4.1.0",


### PR DESCRIPTION
This PR bumps lib version to 1.2.1 (contains updated logging for WI AB#86279).