### PR TITLE
Return previous value for PROMISE_CONCURRENCY

### DIFF
--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -18,7 +18,7 @@ import { promiseMap } from "../../../util/misc/promise-map";
 import { formatDate } from "./lib/date-helper";
 
 const debug = require("debug")("appcenter-cli:commands:codepush:deployments:list");
-const PROMISE_CONCURRENCY = 20;
+const PROMISE_CONCURRENCY = 30;
 
 @help("List the deployments associated with an app")
 export default class CodePushDeploymentListListCommand extends AppCommand {


### PR DESCRIPTION
We should return PROMISE_CONCURRENCY to prev version because it's not an effective strategy for the customer.

[AB#86388](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/86388)
[AB#85283](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/85283)