### PR TITLE
[CodePush] Corrected dependency check

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -505,7 +505,7 @@ export function getReactNativeVersion(): string {
   }
 
   return (
-    projectPackageJson.dependencies["react-native"] ||
+    (projectPackageJson.dependencies && projectPackageJson.dependencies["react-native"]) ||
     (projectPackageJson.devDependencies && projectPackageJson.devDependencies["react-native"])
   );
 }


### PR DESCRIPTION
Issue: In case of package.json file have no dependencies or doesn't have this section - codepush  fails when trying to determine the version of React Native.
Ref: #1485
Solution: Corrected dependency check logic.