### PR TITLE
[CodePush] release-react: add param to specify path to Xcode project file

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -106,7 +106,6 @@ export async function getReactNativeProjectAppVersion(
         if (resolvedPbxprojFile) {
           // If a plist file path is explicitly provided, then we don't
           // need to attempt to "resolve" it within the well-known locations.
-
           if (!resolvedPbxprojFile.endsWith(pbxprojFileName)) {
             // Specify path to pbxproj file if the provided file path is an Xcode project file.
             resolvedPbxprojFile = path.join(resolvedPbxprojFile, pbxprojFileName);

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -109,7 +109,7 @@ export async function getReactNativeProjectAppVersion(
 
           if (!resolvedPbxprojFile.endsWith(pbxprojFileName)) {
             // Specify path to pbxproj file if the provided file path is an Xcode project file.
-            resolvedPbxprojFile = path.join(resolvedPbxprojFile, pbxprojFileName)
+            resolvedPbxprojFile = path.join(resolvedPbxprojFile, pbxprojFileName);
           }
           if (!fileExists(resolvedPbxprojFile)) {
             throw new Error("The specified pbx project file doesn't exist. Please check that the provided path is correct.");

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -101,17 +101,22 @@ export async function getReactNativeProjectAppVersion(
           );
         }
 
+        const pbxprojFileName = "project.pbxproj";
         let resolvedPbxprojFile: string = versionSearchParams.projectFile;
         if (resolvedPbxprojFile) {
           // If a plist file path is explicitly provided, then we don't
           // need to attempt to "resolve" it within the well-known locations.
+
+          if (!resolvedPbxprojFile.endsWith(pbxprojFileName)) {
+            // Specify path to pbxproj file if the provided file path is an Xcode project file.
+            resolvedPbxprojFile = path.join(resolvedPbxprojFile, pbxprojFileName)
+          }
           if (!fileExists(resolvedPbxprojFile)) {
             throw new Error("The specified pbx project file doesn't exist. Please check that the provided path is correct.");
           }
         } else {
           const iOSDirectory = "ios";
           const xcodeprojDirectory = `${projectName}.xcodeproj`;
-          const pbxprojFileName = "project.pbxproj";
           const pbxprojKnownLocations = [
             path.join(iOSDirectory, xcodeprojDirectory, pbxprojFileName),
             path.join(iOSDirectory, pbxprojFileName),

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -19,6 +19,7 @@ export interface VersionSearchParams {
   plistFilePrefix: string;
   gradleFile: string;
   buildConfigurationName: string;
+  projectFile: string;
 }
 
 interface XCBuildConfiguration {
@@ -100,20 +101,30 @@ export async function getReactNativeProjectAppVersion(
           );
         }
 
-        const iOSDirectory = "ios";
-        const xcodeprojDirectory = `${projectName}.xcodeproj`;
-        const pbxprojFileName = "project.pbxproj";
-        const pbxprojKnownLocations = [
-          path.join(iOSDirectory, xcodeprojDirectory, pbxprojFileName),
-          path.join(iOSDirectory, pbxprojFileName),
-        ];
-        const resolvedPbxprojFile = pbxprojKnownLocations.find(fileExists);
-        if (!resolvedPbxprojFile) {
-          throw new Error(
-            `Unable to find either of the following pbxproj files in order to infer your app's binary version: "${pbxprojKnownLocations.join(
-              '", "'
-            )}".`
-          );
+        let resolvedPbxprojFile: string = versionSearchParams.projectFile;
+        if (resolvedPbxprojFile) {
+          // If a plist file path is explicitly provided, then we don't
+          // need to attempt to "resolve" it within the well-known locations.
+          if (!fileExists(resolvedPbxprojFile)) {
+            throw new Error("The specified pbx project file doesn't exist. Please check that the provided path is correct.");
+          }
+        } else {
+          const iOSDirectory = "ios";
+          const xcodeprojDirectory = `${projectName}.xcodeproj`;
+          const pbxprojFileName = "project.pbxproj";
+          const pbxprojKnownLocations = [
+            path.join(iOSDirectory, xcodeprojDirectory, pbxprojFileName),
+            path.join(iOSDirectory, pbxprojFileName),
+          ];
+          resolvedPbxprojFile = pbxprojKnownLocations.find(fileExists);
+
+          if (!resolvedPbxprojFile) {
+            throw new Error(
+              `Unable to find either of the following pbxproj files in order to infer your app's binary version: "${pbxprojKnownLocations.join(
+                '", "'
+              )}".`
+            );
+          }
         }
 
         const xcodeProj = xcode.project(resolvedPbxprojFile).parseSync();

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -55,7 +55,6 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   public plistFile: string;
 
   @help("Path to the project.pbxproj file")
-  @shortName("px")
   @longName("project-file")
   @hasArg
   public projectFile: string;

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -54,6 +54,12 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @longName("plist-file")
   public plistFile: string;
 
+  @help("Path to the project.pbxproj file")
+  @shortName("px")
+  @longName("project-file")
+  @hasArg
+  public projectFile: string;
+
   @help("Prefix to append to the file name when attempting to find your app's Info.plist file (iOS only)")
   @longName("plist-file-prefix")
   @hasArg
@@ -183,6 +189,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
         plistFilePrefix: this.plistFilePrefix,
         gradleFile: this.gradleFile,
         buildConfigurationName: this.buildConfigurationName,
+        projectFile: this.projectFile,
       } as VersionSearchParams;
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
     }

--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -54,10 +54,11 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @longName("plist-file")
   public plistFile: string;
 
-  @help("Path to the project.pbxproj file")
-  @longName("project-file")
+  @help("Path to the Xcode project or project.pbxproj file")
+  @shortName("xp")
+  @longName("xcode-project-file")
   @hasArg
-  public projectFile: string;
+  public xcodeProjectFile: string;
 
   @help("Prefix to append to the file name when attempting to find your app's Info.plist file (iOS only)")
   @longName("plist-file-prefix")
@@ -188,7 +189,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
         plistFilePrefix: this.plistFilePrefix,
         gradleFile: this.gradleFile,
         buildConfigurationName: this.buildConfigurationName,
-        projectFile: this.projectFile,
+        projectFile: this.xcodeProjectFile,
       } as VersionSearchParams;
       this.targetBinaryVersion = await getReactNativeProjectAppVersion(versionSearchParams);
     }


### PR DESCRIPTION
Issue: In multi workspaces code structure, if the app is in a child folder and all dependencies is declared from root folder. I will need to run the command from root folder. In this case the file project.pbxproj will not be found in these paths: "ios/my-app.xcodeproj/project.pbxproj", "ios/project.pbxproj".
Ref: #851
Solution: Add a param to let user to manually specify path to to Xcode project or project.pbxproj file.