### PR TITLE
[test-cloud] Generate a shell command safely for xamarin uitest

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -53,7 +53,10 @@ export class UITestPreparer {
 
     if (exitCode !== 0) {
       const message = this.convertErrorCode(exitCode);
-      throw new TestCloudError(`Failed to prepare UI Test artifacts using command "test-cloud.exe prepare" with error message:${os.EOL}${message}`, exitCode);
+      throw new TestCloudError(
+        `Failed to prepare UI Test artifacts using command "test-cloud.exe prepare" with error message:${os.EOL}${message}`,
+        exitCode
+      );
     }
 
     return path.join(this.artifactsDir, "manifest.json");

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -48,7 +48,7 @@ export class UITestPreparer {
     this.validateArguments();
 
     const command = await this.getPrepareCommand();
-    debug(`Executing command ${command}`);
+    debug(`Executing "test-cloud.exe prepare" command`);
     const exitCode = await process.execWithArgsAndAwait(command.file, command.args, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -49,7 +49,7 @@ export class UITestPreparer {
 
     const command = await this.getPrepareCommand();
     debug(`Executing "test-cloud.exe prepare" command`);
-    const exitCode = await process.execWithArgsAndAwait(command.file, command.args, this.outMessage, this.outMessage);
+    const exitCode = await process.execWithArgsAndWait(command.file, command.args, this.outMessage, this.outMessage);
 
     if (exitCode !== 0) {
       const message = this.convertErrorCode(exitCode);

--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -53,7 +53,7 @@ export class UITestPreparer {
 
     if (exitCode !== 0) {
       const message = this.convertErrorCode(exitCode);
-      throw new TestCloudError(`Cannot prepare UI Test artifacts using command: ${command}.${os.EOL}${os.EOL}${message}`, exitCode);
+      throw new TestCloudError(`Failed to prepare UI Test artifacts using command "test-cloud.exe prepare" with error message:${os.EOL}${message}`, exitCode);
     }
 
     return path.join(this.artifactsDir, "manifest.json");
@@ -156,33 +156,33 @@ export class UITestPreparer {
       args.push(executable);
     }
 
-    args.push("prepare", `"${this.appPath}"`);
+    args.push("prepare", this.appPath);
 
     if (this.storeFile) {
-      args.push("keystore", `"${this.storeFile}"`, `"${this.storePassword}"`, `"${this.keyAlias}"`, `"${this.keyPassword}"`);
+      args.push("keystore", this.storeFile, this.storePassword, this.keyAlias, this.keyPassword);
     }
 
-    args.push("--assembly-dir", `"${this.buildDir}"`, "--artifacts-dir", `"${this.artifactsDir}"`);
+    args.push("--assembly-dir", this.buildDir, "--artifacts-dir", this.artifactsDir);
 
     if (this.signInfo) {
-      args.push("--sign-info", `"${this.signInfo}"`);
+      args.push("--sign-info", this.signInfo);
     }
 
     if (this.fixture) {
       this.fixture.forEach((item) => {
-        args.push("--fixture", `"${item}"`);
+        args.push("--fixture", item);
       });
     }
 
     if (this.includeCategory) {
       this.includeCategory.forEach((category) => {
-        args.push("--include", `"${category}"`);
+        args.push("--include", category);
       });
     }
 
     if (this.excludeCategory) {
       this.excludeCategory.forEach((category) => {
-        args.push("--exclude", `"${category}"`);
+        args.push("--exclude", category);
       });
     }
 

--- a/src/util/misc/process-helper.ts
+++ b/src/util/misc/process-helper.ts
@@ -29,3 +29,37 @@ export function execAndWait(command: string, onStdOut?: (text: string) => void, 
     });
   });
 }
+
+export function execWithArgsAndAwait(
+  file: string,
+  args: string[],
+  onStdOut?: (text: string) => void,
+  onStdErr?: (text: string) => void
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    if (!onStdOut) {
+      onStdOut = (text) => out.text(text);
+    }
+    if (!onStdErr) {
+      onStdErr = (text) => out.text(text);
+    }
+
+    const process = child_process.execFile(file, args);
+
+    process.on("exit", (exitCode: number) => {
+      resolve(exitCode);
+    });
+
+    process.on("error", (message: string) => {
+      reject(new Error(message));
+    });
+
+    process.stdout.on("data", (data) => {
+      onStdOut(data as string);
+    });
+
+    process.stderr.on("data", (data) => {
+      onStdErr(data as string);
+    });
+  });
+}

--- a/src/util/misc/process-helper.ts
+++ b/src/util/misc/process-helper.ts
@@ -30,7 +30,7 @@ export function execAndWait(command: string, onStdOut?: (text: string) => void, 
   });
 }
 
-export function execWithArgsAndAwait(
+export function execWithArgsAndWait(
   file: string,
   args: string[],
   onStdOut?: (text: string) => void,

--- a/test/commands/test/run/uitest-test.ts
+++ b/test/commands/test/run/uitest-test.ts
@@ -7,8 +7,13 @@ let testCloudCommand = "";
 
 // Mocking process-helper
 MockRequire("../../../../src/util/misc/process-helper", {
-  execAndWait: async (command: string, onStdOut?: (text: string) => void, onStdErr?: (text: string) => void): Promise<number> => {
-    testCloudCommand = command;
+  execWithArgsAndWait: async (
+    file: string,
+    args: string[],
+    onStdOut?: (text: string) => void,
+    onStdErr?: (text: string) => void
+  ): Promise<number> => {
+    testCloudCommand = `${file} ${args.join(" ")}`;
     return 0;
   },
 });

--- a/test/commands/test/run/uitest-test.ts
+++ b/test/commands/test/run/uitest-test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { CommandArgs } from "../../../../src/util/commandline";
 
 let testCloudCommand = "";
+let testCloudCommandArgs: string[] = [];
 
 // Mocking process-helper
 MockRequire("../../../../src/util/misc/process-helper", {
@@ -13,7 +14,8 @@ MockRequire("../../../../src/util/misc/process-helper", {
     onStdOut?: (text: string) => void,
     onStdErr?: (text: string) => void
   ): Promise<number> => {
-    testCloudCommand = `${file} ${args.join(" ")}`;
+    testCloudCommand = file;
+    testCloudCommandArgs = args;
     return 0;
   },
 });
@@ -23,6 +25,7 @@ import RunUITestsCommand from "../../../../src/commands/test/run/uitest";
 describe("Validating UITest run", () => {
   it("should include sign-info for test-cloud prepare command", async () => {
     // Arrange
+    const toolsDir = path.join(__dirname, "../sample-test-workspace");
     const args: CommandArgs = {
       command: ["test", "run", "uitest"],
       commandPath: "Test",
@@ -38,7 +41,7 @@ describe("Validating UITest run", () => {
         "--build-dir",
         "test_dir",
         "--uitest-tools-dir",
-        path.join(__dirname, "../sample-test-workspace"),
+        toolsDir,
         "--sign-info",
         "testserver.si",
       ],
@@ -50,10 +53,13 @@ describe("Validating UITest run", () => {
     await (command as any).prepareManifest("artifacts_dir");
 
     // Assert
-    expect(testCloudCommand).contain('prepare "test-apps/Android/SampleApp.apk"');
-    expect(testCloudCommand).contain('--sign-info "testserver.si"');
-    expect(testCloudCommand).contain('--assembly-dir "test_dir"');
-    expect(testCloudCommand).contain('--artifacts-dir "artifacts_dir"');
+    expect(testCloudCommand).equal("mono");
+    expect(testCloudCommandArgs).satisfy((args: string[]) => args.indexOf(path.join(toolsDir, "test-cloud.exe")) === 0);
+    const argsStr = testCloudCommandArgs.join(" ");
+    expect(argsStr).contain("prepare test-apps/Android/SampleApp.apk");
+    expect(argsStr).contain("--sign-info testserver.si");
+    expect(argsStr).contain("--assembly-dir test_dir");
+    expect(argsStr).contain("--artifacts-dir artifacts_dir");
   });
 });
 


### PR DESCRIPTION
This PR fixes the following security warning:

> Shell command built from environment values
> Building a shell command string with values from the enclosing environment may cause subtle bugs or vulnerabilities.

The solution is to replace `exec` with `execFile`, providing a command and arguments separately.