### PR TITLE
Correcting argument name of error output

### DIFF
--- a/src/commands/test/lib/uitest-preparer.ts
+++ b/src/commands/test/lib/uitest-preparer.ts
@@ -139,7 +139,7 @@ export class UITestPreparer {
     if (this.storeFile || this.storePassword || this.keyAlias || this.keyPassword) {
       if (!(this.storeFile && this.storePassword && this.keyAlias && this.keyPassword)) {
         throw new Error(
-          "If keystore is used, all of the following arguments must be set: --store-file, --store-password, --key-alias, --key-password"
+          "If keystore is used, all of the following arguments must be set: --store-path, --store-password, --key-alias, --key-password"
         );
       }
     }


### PR DESCRIPTION
This PR fixes the argument name in the following error message:

> Error: If keystore is used, all of the following arguments must be set: --store-file, --store-password, --key-alias, --key-password

`--store-file` argument name is no more used, so it has been replaced with correct argument name `--store-path`.