### PR TITLE
[appcenter-file-upload-client-node] bump version to 1.2.2

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "File Uploader Client for Node",
   "homepage": "https://github.com/microsoft/appcenter-cli",
   "author": "Microsoft",


### PR DESCRIPTION
This PRs bumps version to 1.2.2 in order to publish new package - `proxy-agent@4.0.1` dependency from 1.2.1 discovered to be vulnerable https://github.com/advisories/GHSA-9j49-mfvp-vmhm - which is fixed in `proxy-agent@5.0.0` https://github.com/TooTallNate/node-proxy-agent/releases/tag/5.0.0