### PR TITLE
Bump appcenter-file-upload-client-node to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -946,7 +946,7 @@
       }
     },
     "appcenter-file-upload-client-node": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.1.tgz",
       "integrity": "sha512-uyAgXCTu1HrMwfjMEQW3cGIwDGmoqkaarM6lwTUHkcZJdbutaoVBNn0Oaymt/xOTvwjVgvzcMIw5Oz+2c7EB9w==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@xmldom/xmldom": "0.7.5",
     "abort-controller": "3.0.0",
     "appcenter-file-upload-client": "0.0.24",
-    "appcenter-file-upload-client-node": "1.2.1",
+    "appcenter-file-upload-client-node": "1.2.2",
     "azure-storage": "2.10.4",
     "bplist": "0.0.4",
     "chalk": "4.1.2",


### PR DESCRIPTION
This PR bumps lib version to 1.2.2