### PR TITLE
Revert "Bump typescript from 4.3.5 to 4.4.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8455,9 +8455,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unc-path-regex": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "sinon": "11.1.2",
     "ts-node": "9.1.1",
     "typemoq": "2.1.0",
-    "typescript": "4.4.3"
+    "typescript": "4.3.5"
   },
   "dependencies": {
     "@xmldom/xmldom": "0.7.5",


### PR DESCRIPTION
Reverts microsoft/appcenter-cli#1614 to fix Error: Cannot read property 'filterIncludedFiles' of undefined.