### PR TITLE
Fixed getting release for distributionGroup

### DIFF
--- a/src/commands/distribute/groups/download.ts
+++ b/src/commands/distribute/groups/download.ts
@@ -59,7 +59,7 @@ export default class DownloadBinaryFromDistributionGroupCommand extends AppComma
 
     const downloadUrl: string = await out.progress(
       "Getting release URL...",
-      this.getLastReleaseUrl(client, app, !_.isNil(this.releaseId) ? this.releaseId : "latest", this.distributionGroup)
+      this.getReleaseUrl(client, app, !_.isNil(this.releaseId) ? this.releaseId : "latest", this.distributionGroup)
     );
 
     const directoryPath = await this.getDirectoryPath(this.directory);
@@ -84,13 +84,13 @@ export default class DownloadBinaryFromDistributionGroupCommand extends AppComma
     }
   }
 
-  private async getLastReleaseUrl(
+  private async getReleaseUrl(
     client: AppCenterClient,
     app: DefaultApp,
     releaseId: string,
     distributionGroup: string
   ): Promise<string> {
-    debug("Getting download URL for the latest release of the specified distribution group");
+    debug(`Getting download URL for the ${releaseId} release of the specified distribution group`);
     try {
       const httpRequest = await clientRequest<models.ReleaseDetailsResponse>((cb) =>
         client.releasesOperations.getLatestByDistributionGroup(app.ownerName, app.appName, distributionGroup, releaseId, cb)
@@ -107,8 +107,8 @@ export default class DownloadBinaryFromDistributionGroupCommand extends AppComma
         case "not_found":
           throw failure(ErrorCodes.InvalidParameter, `distribution group ${distributionGroup} doesn't exist`);
         default:
-          debug(`Failed to get details of the latest release for distribution group ${distributionGroup} - ${inspect(error)}`);
-          throw failure(ErrorCodes.Exception, "failed to get details of the latest release for the distribution group");
+          debug(`Failed to get details of the ${releaseId} release for distribution group ${distributionGroup} - ${inspect(error)}`);
+          throw failure(ErrorCodes.Exception, `failed to get details of the ${releaseId} release for the distribution group`);
       }
     }
   }

--- a/test/commands/distribute/groups/download-test.ts
+++ b/test/commands/distribute/groups/download-test.ts
@@ -38,11 +38,7 @@ describe("distribute groups download command", () => {
     // Arrange
     const releaseFilePath = Temp.path({ prefix: "releaseFile", dir: tmpFolderPath });
     const executionScope = _.flow(setupGetLatestReleaseDetailsResponse, setupGetReleaseFileResponse)(Nock(fakeHost));
-    const skippedScope = _.flow(
-      setupGetReleasesForDistributionGroupResponse,
-      setupGetReleaseDetailsResponse,
-      setupGetReleaseFile2Response
-    )(Nock(fakeHost));
+    const skippedScope = _.flow(setupGetReleaseDetailsResponse, setupGetReleaseFile2Response)(Nock(fakeHost));
 
     // Act
     const command = new DownloadBinaryFromDistributionGroupCommand(
@@ -59,11 +55,7 @@ describe("distribute groups download command", () => {
   it("gets the specified release and checks that it was released to the distribution group", async () => {
     // Arrange
     const releaseFilePath = Temp.path({ prefix: "releaseFile", dir: tmpFolderPath });
-    const executionScope = _.flow(
-      setupGetReleasesForDistributionGroupResponse,
-      setupGetReleaseDetailsResponse,
-      setupGetReleaseFile2Response
-    )(Nock(fakeHost));
+    const executionScope = _.flow(setupGetReleaseDetailsResponse, setupGetReleaseFile2Response)(Nock(fakeHost));
     const skippedScope = _.flow(setupGetLatestReleaseDetailsResponse, setupGetReleaseFileResponse)(Nock(fakeHost));
 
     // Act
@@ -122,20 +114,10 @@ describe("distribute groups download command", () => {
     return nockScope.get(fakeDownloadUrl).reply(200, releaseFileContent);
   }
 
-  function setupGetReleasesForDistributionGroupResponse(nockScope: Nock.Scope) {
-    return nockScope
-      .get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}/releases`)
-      .reply(200, [
-        {
-          id: Number(fakeReleaseId),
-        },
-      ]);
-  }
-
   function setupGetReleaseDetailsResponse(nockScope: Nock.Scope) {
-    return nockScope.get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/releases/${fakeReleaseId}`).reply(200, {
-      download_url: fakeHost + fakeDownloadUrl2,
-    });
+    return nockScope
+      .get(`/v0.1/apps/${fakeAppOwner}/${fakeAppName}/distribution_groups/${fakeDistributionGroupName}/releases/${fakeReleaseId}`)
+      .reply(200, { download_url: fakeHost + fakeDownloadUrl2 });
   }
 
   function setupGetReleaseFile2Response(nockScope: Nock.Scope) {


### PR DESCRIPTION
**Current behavior:**
Obtaining a `downloadUrl` for downloading a release takes place in 2 stages: getting a list of releases for a distributionGroup (max 200) and if the required release is in the list, then a `downloadUrl` will receive.

**The problem:**
The max count of releases is 200. If more than 200 releases have been distributed to the distributionGroup, then the customer receives an error: "release XX was not distributed to distribution group GROUP_NAME".

**The solution:**
Fixed getting `downloadUrl` for release in one request: [/v0.1/apps/{owner_name}/{app_name}/distribution_groups/{distribution_group_name}/releases/{release_id}](https://openapi.appcenter.ms/?url=https%3A%2F%2Fapi.appcenter.ms%2Fpreview%2Fswagger-internal.json#/distribute/releases_getLatestByDistributionGroup)