### PR TITLE
[appcenter-file-upload-client-node] bump version to 1.2.4

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "File Uploader Client for Node",
   "homepage": "https://github.com/microsoft/appcenter-cli",
   "author": "Microsoft",


### PR DESCRIPTION
This PRs bumps version to 1.2.3 in order to include new changes presented in the following PRs:
https://github.com/microsoft/appcenter-cli/pull/1732
https://github.com/microsoft/appcenter-cli/pull/1726