### PR TITLE
Fix Hermes enabled check for iOS

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -498,7 +498,7 @@ export function getiOSHermesEnabled(podFile: string): boolean {
 
   try {
     const podFileContents = fs.readFileSync(podPath).toString();
-    return /:hermes_enabled(\s+|\n+)?=>(\s+|\n+)?true/.test(podFileContents);
+    return /(:hermes_enabled(\s+|\n+)?=>(\s+|\n+)?true|hermes_enabled:(\s+|\n+)?true)/.test(podFileContents);
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
Noticed that despite Hermes being enabled I wasn't seeing the `appcenter-cli` try to create Hermes bytecode for the build -- this was because the check for Hermes was too specific -- it expects:
```
:hermes_enables => true
```
when equally valid is new Ruby syntax:
```
hermes_enabled: true
```

This change adds the latter case as well to the test.
