### PR TITLE
Print errors on console.error

### DIFF
--- a/bin/appcenter.js
+++ b/bin/appcenter.js
@@ -49,9 +49,9 @@ function runCli() {
       const chalk = require("chalk");
       const ioOptions = require("../dist/util/interaction/io-options");
       if (ioOptions.formatIsJson()) {
-        console.log(`${chalk.red(JSON.stringify(result))}`);
+        console.error(`${chalk.red(JSON.stringify(result))}`);
       } else {
-        console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+        console.error(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
       }
       process.exit(result.errorCode);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ const runner = commandRunner(path.join(__dirname, "commands"));
 runner(process.argv.slice(2)).then((result: CommandResult) => {
   if (failed(result)) {
     if (formatIsJson()) {
-      console.log(`${chalk.red(JSON.stringify(result))}`);
+      console.error(`${chalk.red(JSON.stringify(result))}`);
     } else {
-      console.log(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
+      console.error(`${chalk.bold.red("Error:")} ${result.errorMessage}`);
     }
     process.exit(result.errorCode);
   }


### PR DESCRIPTION
When using appcenter CLI in scripts, CLI's errors are not reported to stderr
This causes error stream logs to be missed out.

The script reports all errors to stdout