### PR TITLE
Fix Appium template

### DIFF
--- a/src/commands/test/lib/templates/appium/android/pom.xml
+++ b/src/commands/test/lib/templates/appium/android/pom.xml
@@ -4,13 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <repositories>
-    <repository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
-
   <groupId>com.xamarin.samples.appium</groupId>
   <artifactId>LaunchTest</artifactId>
   <version>1.0</version>
@@ -18,7 +11,7 @@
     <dependency>
       <groupId>io.appium</groupId>
       <artifactId>java-client</artifactId>
-      <version>7.1.0</version>
+      <version>7.6.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -29,7 +22,7 @@
     <dependency>
       <groupId>com.microsoft.appcenter</groupId>
       <artifactId>appium-test-extension</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
     </dependency>
   </dependencies>
 

--- a/src/commands/test/lib/templates/appium/android/src/test/java/com/azure/mobile/app/test/LaunchTest.java
+++ b/src/commands/test/lib/templates/appium/android/src/test/java/com/azure/mobile/app/test/LaunchTest.java
@@ -5,6 +5,8 @@ import com.microsoft.appcenter.appium.EnhancedAndroidDriver;
 import org.junit.*;
 import org.junit.rules.TestWatcher;
 import io.appium.java_client.MobileElement;
+
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.net.MalformedURLException;
@@ -45,14 +47,14 @@ public class LaunchTest {
         Random rand = new Random();
 
         for (int i=0; i<10; i++) {
-            List<MobileElement> buttons = driver.findElementsByClassName("android.widget.Button");
+            List<WebElement> buttons = driver.findElementsByClassName("android.widget.Button");
 
             if (buttons.size() == 0) {
                 return;
             }
 
             try {
-                MobileElement button = buttons.get(rand.nextInt(buttons.size()));
+                MobileElement button = (MobileElement) buttons.get(rand.nextInt(buttons.size()));
                 button.click();
             } catch (Exception ex) {
                 // Fail silently, this is probably due to the number of buttons on the page being reduced between

--- a/src/commands/test/lib/templates/appium/ios/pom.xml
+++ b/src/commands/test/lib/templates/appium/ios/pom.xml
@@ -4,13 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <repositories>
-    <repository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
-  </repositories>
-
   <groupId>com.xamarin.samples.appium</groupId>
   <artifactId>LaunchTest</artifactId>
   <version>1.0</version>
@@ -18,7 +11,7 @@
     <dependency>
       <groupId>io.appium</groupId>
       <artifactId>java-client</artifactId>
-      <version>7.1.0</version>
+      <version>7.6.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -29,7 +22,7 @@
     <dependency>
       <groupId>com.microsoft.appcenter</groupId>
       <artifactId>appium-test-extension</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
     </dependency>
   </dependencies>
 

--- a/src/commands/test/lib/templates/appium/ios/src/test/java/com/azure/mobile/app/test/LaunchTest.java
+++ b/src/commands/test/lib/templates/appium/ios/src/test/java/com/azure/mobile/app/test/LaunchTest.java
@@ -5,6 +5,8 @@ import com.microsoft.appcenter.appium.EnhancedIOSDriver;
 import org.junit.*;
 import org.junit.rules.TestWatcher;
 import io.appium.java_client.MobileElement;
+
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.net.MalformedURLException;
@@ -24,7 +26,7 @@ public class LaunchTest {
 
         capabilities.setCapability("automationName", "XCUITest");
         capabilities.setCapability("platformName", "iOS");
-        capabilities.setCapability("deviceName", "iPhone 6");
+        capabilities.setCapability("deviceName", "iPhone 11 Pro");
         capabilities.setCapability("app", "/path/to/app.app");
 
         URL url = new URL("http://localhost:4723/wd/hub");
@@ -41,19 +43,19 @@ public class LaunchTest {
         driver.label("App has launched");
     }
 
-    //@Test
+    @Test
     public void tapRandomButtonsTest() {
         Random rand = new Random();
 
         for (int i=0; i<10; i++) {
-            List<MobileElement> buttons = driver.findElementsByClassName("UIAButton");
+            List<WebElement> buttons = driver.findElementsByClassName("UIAButton");
 
             if (buttons.size() == 0) {
                 return;
             }
 
             try {
-                MobileElement button = buttons.get(rand.nextInt(buttons.size()));
+                MobileElement button = (MobileElement) buttons.get(rand.nextInt(buttons.size()));
                 button.click();
             } catch (Exception ex) {
                 // Fail silently, this is probably due to the number of buttons on the page being reduced between

--- a/src/commands/test/lib/templates/appium/ios/src/test/java/com/azure/mobile/app/test/LaunchTest.java
+++ b/src/commands/test/lib/templates/appium/ios/src/test/java/com/azure/mobile/app/test/LaunchTest.java
@@ -43,7 +43,7 @@ public class LaunchTest {
         driver.label("App has launched");
     }
 
-    @Test
+    //@Test
     public void tapRandomButtonsTest() {
         Random rand = new Random();
 


### PR DESCRIPTION
This PR fixes the following vulnerability issues:

CVE-2022-22965                          |org.springframework:spring-beans 5.1.6.RELEASE|Critical                     
CVE-2022-22965                          |org.springframework:spring-core 5.1.6.RELEASE|Critical                   
CVE-2014-0114                           |commons-beanutils:commons-beanutils 1.9.2|High                       
CVE-2019-10086                          |commons-beanutils:commons-beanutils 1.9.2|High                   
CVE-2020-11979                          |org.apache.ant:ant 1.10.3               |High                      
CVE-2022-24785                          |moment 2.29.1                           |High                        
WS-2021-0419                            |com.google.code.gson:gson 2.8.5         |High             
CVE-2020-13956                          |org.apache.httpcomponents:httpclient 4.5.8|Medium                 
CVE-2020-1945                           |org.apache.ant:ant 1.10.3               |Medium                    
CVE-2021-22096                          |org.springframework:spring-core 5.1.6.RELEASE|Medium                   
CVE-2021-36373                          |org.apache.ant:ant 1.10.3               |Medium                     
CVE-2021-36374                          |org.apache.ant:ant 1.10.3               |Medium                  
CVE-2022-22950                          |org.springframework:spring-core 5.1.6.RELEASE|Medium                         
CVE-2022-22950                          |org.springframework:spring-expression 5.1.6.RELEASE|Medium   


This PR also removes JCenter as a repository. 

[AB#92264](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/92264)
[AB#92263](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/92263)
[AB#91217](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/91217)
[AB#92205](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/92205)