### PR TITLE
Update versions of vulnerable packages

### DIFF
--- a/src/commands/test/lib/templates/appium/android/pom.xml
+++ b/src/commands/test/lib/templates/appium/android/pom.xml
@@ -24,6 +24,22 @@
       <artifactId>appium-test-extension</artifactId>
       <version>1.6</version>
     </dependency>
+    <!-- Following packages are not used in project directly, they added to fix vulnerability alerts -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>5.3.18</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>5.3.17</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/commands/test/lib/templates/appium/ios/pom.xml
+++ b/src/commands/test/lib/templates/appium/ios/pom.xml
@@ -24,6 +24,22 @@
       <artifactId>appium-test-extension</artifactId>
       <version>1.6</version>
     </dependency>
+    <!-- Following packages are not used in project directly, they added to fix vulnerability alerts -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>5.3.18</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>5.3.17</version>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
This PR fixes the following vulnerability issues:

https://github.com/advisories/GHSA-36p3-wjmg-h94x |org.springframework:spring-beans 5.1.6.RELEASE|Critical
https://github.com/advisories/GHSA-36p3-wjmg-h94x |org.springframework:spring-core 5.1.6.RELEASE|Critical
https://github.com/advisories/GHSA-f62v-xpxf-3v68 |org.apache.ant:ant 1.10.3 |High
https://github.com/advisories/GHSA-8hfj-j24r-96c4 |moment 2.29.1 |High
WS-2021-0419 |com.google.code.gson:gson 2.8.5 |High
https://github.com/advisories/GHSA-7r82-7xv7-xcpj |org.apache.httpcomponents:httpclient 4.5.8|Medium
https://github.com/advisories/GHSA-4p6w-m9wc-c9c9 |org.apache.ant:ant 1.10.3 |Medium
CVE-2021-22096 |org.springframework:spring-core 5.1.6.RELEASE|Medium
https://github.com/advisories/GHSA-q5r4-cfpx-h6fh |org.apache.ant:ant 1.10.3 |Medium
https://github.com/advisories/GHSA-5v34-g2px-j4fw |org.apache.ant:ant 1.10.3 |Medium
https://github.com/advisories/GHSA-558x-2xjg-6232 |org.springframework:spring-core 5.1.6.RELEASE|Medium
https://github.com/advisories/GHSA-558x-2xjg-6232 |org.springframework:spring-expression 5.1.6.RELEASE|Medium