### PR TITLE
Fix getAndroidHermesEnabled

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -483,7 +483,7 @@ export function getAndroidHermesEnabled(gradleFile: string): boolean {
       throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
     })
     .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"] || []).some(line => /^enableHermes\s{0,}:\s{0,}true/.test(line));
+      return Array.from(buildGradle["project.ext.react"] || []).some((line: string) => /^enableHermes\s{0,}:\s{0,}true/.test(line));
     });
 }
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -483,7 +483,7 @@ export function getAndroidHermesEnabled(gradleFile: string): boolean {
       throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
     })
     .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"] || []).some(line => line.startsWith("enableHermes: true"));
+      return Array.from(buildGradle["project.ext.react"] || []).some(line => /^enableHermes\s{0,}:\s{0,}true/.test(line));
     });
 }
 

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -483,7 +483,7 @@ export function getAndroidHermesEnabled(gradleFile: string): boolean {
       throw new Error(`Unable to parse the "${buildGradlePath}" file. Please ensure it is a well-formed Gradle file.`);
     })
     .then((buildGradle: any) => {
-      return Array.from(buildGradle["project.ext.react"] || []).includes("enableHermes: true");
+      return Array.from(buildGradle["project.ext.react"] || []).some(line => line.startsWith("enableHermes: true"));
     });
 }
 


### PR DESCRIPTION
There can be many cases where the line does not exactly match the `enableHermes: true`.
I don't think these changes would be the ultimate solution though 😓 

Case 1

```gradle
project.ext.react = [
        entryFile   : "index.js",
        enableHermes: true  // Enable hermers
]
```

Case 2

```gradle
project.ext.react = [
        enableHermes: true,
        entryFile   : "index.js",
]
```