### PR TITLE
Add "distribute release --timeout <seconds>" option for loading release id.

### DIFF
--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -442,24 +442,24 @@ export default class ReleaseBinaryCommand extends AppCommand {
 
   private async loadReleaseIdUntilSuccess(app: DefaultApp, uploadId: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      const timerId = setInterval(async () => {
+      const check = async () => {
         let response;
         try {
           response = await this.loadReleaseId(app, uploadId);
         } catch (error) {
-          clearInterval(timerId);
           reject(new Error(`Loading release id failed with error: ${error.errorMessage}`));
         }
         const releaseId = response.release_distinct_id;
         debug(`Received release id is ${releaseId}`);
         if (response.upload_status === "readyToBePublished" && releaseId) {
-          clearInterval(timerId);
           resolve(Number(releaseId));
         } else if (response.upload_status === "error") {
-          clearInterval(timerId);
           reject(new Error(`Loading release id failed: ${response.error_details}`));
+        } else {
+          setTimeout(check, 2000);
         }
-      }, 2000);
+      };
+      check();
     });
   }
 

--- a/src/commands/distribute/release.ts
+++ b/src/commands/distribute/release.ts
@@ -465,10 +465,13 @@ export default class ReleaseBinaryCommand extends AppCommand {
         const releaseId = response.release_distinct_id;
         debug(`Received release id is ${releaseId}`);
         if (response.upload_status === "readyToBePublished" && releaseId) {
+          debug(`Loading release id completed, total time: ${(Date.now() - t0) / 1000}`);
           resolve(Number(releaseId));
         } else if (response.upload_status === "error") {
+          debug(`Loading release id completed, total time: ${(Date.now() - t0) / 1000}`);
           reject(new Error(`Loading release id failed: ${response.error_details}`));
         } else if (t1 > t0 && Date.now() >= t1) {
+          debug(`Loading release id completed, total time: ${(Date.now() - t0) / 1000}`);
           reject(new Error(`Loading release id failed by timeout: ${this.timeout}`));
         } else {
           setTimeout(check, 2000);


### PR DESCRIPTION
Add "distribute release --timeout <seconds>" option for loading release id.

The uploading with `distribute release` command internally performs multiple steps found in https://docs.microsoft.com/en-us/appcenter/distribution/uploading . Most steps are performed without any issue, but for large ipa/apk files the step 6

> 6. Once uploaded, there is a short delay before the upload is marked as finished. Poll for this status to get the $RELEASE_ID for the next step:

may take several hours regardless of the success or failure (further details can be found in the discussion with App Center Support: Distribute Issue #KVM78S6P).

This pull request allows to specify a timeout for loadReleaseIdUntilSuccess (429fa0036fc18ba3dc24041b444da60c530728d3). With this option, a user can stop appcenter-cli in reasonable time and restart it if necessary. The pull request also contains other minor refinements (0ab83ddc09a44159ac133bb833ab03cac9284fcc, 0846e65eacfb6a5ceb973434d334907ce3141e40).
