### PR TITLE
use --location=global (npm config deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The recommended Node.js version is 12 or higher.
 ## Installation
 
 ```
-npm install -g appcenter-cli
+npm install --location=global appcenter-cli
 ```
 
 Once installed, use the `appcenter` command. See below for the available commands.


### PR DESCRIPTION
I received the following warning when installing appcenter-cli on npm version 8.11.0

       npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
