### PR TITLE
Codepush: Handle subprocess error cases where exitCode is null.

### DIFF
--- a/src/commands/codepush/lib/electron-utils.ts
+++ b/src/commands/codepush/lib/electron-utils.ts
@@ -76,9 +76,9 @@ export function runWebPackBundleCommand(
       console.error(data.toString().trim());
     });
 
-    webpackProcess.on("close", (exitCode: number) => {
-      if (exitCode) {
-        reject(new Error(`"webpack bundle" command exited with code ${exitCode}.`));
+    webpackProcess.on("close", (exitCode: number, signal: string) => {
+      if (exitCode !== 0) {
+        reject(new Error(`"webpack bundle" command failed (exitCode=${exitCode}, signal=${signal}).`));
       }
 
       resolve(null as void);

--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -338,9 +338,9 @@ export function runReactNativeBundleCommand(
       console.error(data.toString().trim());
     });
 
-    reactNativeBundleProcess.on("close", (exitCode: number) => {
-      if (exitCode) {
-        reject(new Error(`"react-native bundle" command exited with code ${exitCode}.`));
+    reactNativeBundleProcess.on("close", (exitCode: number, signal: string) => {
+      if (exitCode !== 0) {
+        reject(new Error(`"react-native bundle" command failed (exitCode=${exitCode}, signal=${signal}).`));
       }
 
       resolve(null as void);
@@ -391,9 +391,9 @@ export function runHermesEmitBinaryCommand(
       console.error(data.toString().trim());
     });
 
-    hermesProcess.on("close", (exitCode: number) => {
-      if (exitCode) {
-        reject(new Error(`"hermes" command exited with code ${exitCode}.`));
+    hermesProcess.on("close", (exitCode: number, signal: string) => {
+      if (exitCode !== 0) {
+        reject(new Error(`"hermes" command failed (exitCode=${exitCode}, signal=${signal}).`));
       }
       // Copy HBC bundle to overwrite JS bundle
       const source = path.join(outputFolder, bundleName + ".hbc");
@@ -445,9 +445,9 @@ export function runHermesEmitBinaryCommand(
         console.error(data.toString().trim());
       });
 
-      composeSourceMapsProcess.on("close", (exitCode: number) => {
-        if (exitCode) {
-          reject(new Error(`"compose-source-maps" command exited with code ${exitCode}.`));
+      composeSourceMapsProcess.on("close", (exitCode: number, signal: string) => {
+        if (exitCode !== 0) {
+          reject(new Error(`"compose-source-maps" command failed (exitCode=${exitCode}, signal=${signal}).`));
         }
 
         // Delete the HBC sourceMap, otherwise it will be included in 'code-push' bundle as well

--- a/test/commands/codepush/release-react-test.ts
+++ b/test/commands/codepush/release-react-test.ts
@@ -1028,6 +1028,7 @@ describe("codepush release-react command", function () {
           sandbox.stub(command, "release" as any).resolves(<CommandResult>{ succeeded: true });
           sandbox.stub(fileUtils, "removeReactTmpDir");
           sandbox.stub(ReactNativeTools, "runReactNativeBundleCommand");
+          sandbox.stub(ReactNativeTools, "runHermesEmitBinaryCommand");
           sandbox.stub(fs, "lstatSync").returns({ isDirectory: () => false } as any);
           sandbox.stub(g2js, "parseFile").resolves({ "project.ext.react": ["enableHermes: true"] });
           const childProcessStub = new events.EventEmitter() as any;


### PR DESCRIPTION
This PR aims at fixing issue #911.

In subprocesses' `'close'` event handlers:

```javascript
.on("close", (exitCode: number, signal: string) => { ... }
```

By checking that `exitCode` is `!== 0`, we handle the cases where `exitCode` is `null` and `signal` is defined.
References:
- https://nodejs.org/api/child_process.html#class-childprocess
- https://stackoverflow.com/questions/39159312/child-process-exits-with-code-null


Reopened from https://github.com/microsoft/appcenter-cli/pull/2004 with fixes in ui tests.