### PR TITLE
Fix non existing deployment error message

### DIFF
--- a/src/commands/codepush/deployment/history.ts
+++ b/src/commands/codepush/deployment/history.ts
@@ -79,16 +79,16 @@ export default class CodePushDeploymentHistoryCommand extends AppCommand {
       return success();
     } catch (error) {
       debug(`Failed to get list of CodePush deployments - ${inspect(error)}`);
-      if (error.statusCode === 404) {
+      if (error.statusCode === 404 && error.response.body === `Deployment "${this.deploymentName}" does not exist.`) {
+        const deploymentNotExistErrorMsg = `The deployment ${chalk.bold(this.deploymentName)} does not exist.`;
+        return failure(ErrorCodes.Exception, deploymentNotExistErrorMsg);
+      } else if (error.statusCode === 404) {
         const appNotFoundErrorMsg = `The app ${
           this.identifier
         } does not exist. Please double check the name, and provide it in the form owner/appname. \nRun the command ${chalk.bold(
           `${scriptName} apps list`
         )} to see what apps you have access to.`;
         return failure(ErrorCodes.NotFound, appNotFoundErrorMsg);
-      } else if (error.statusCode === 400) {
-        const deploymentNotExistErrorMsg = `The deployment ${chalk.bold(this.deploymentName)} does not exist.`;
-        return failure(ErrorCodes.Exception, deploymentNotExistErrorMsg);
       } else {
         return failure(ErrorCodes.Exception, error.response.body);
       }

--- a/test/commands/codepush/deployment/history-test.ts
+++ b/test/commands/codepush/deployment/history-test.ts
@@ -71,7 +71,7 @@ describe("codepush deployment history", () => {
         .get(`/v0.1/apps/${testData.fakeAppIdentifier}/deployments/${testData.fakeNonExistentDeploymentName}/releases`)
         .reply((uri, requestBody) => {
           requestReleasesSpy();
-          return [400, {}];
+          return [404, `Deployment "${testData.fakeNonExistentDeploymentName}" does not exist.`];
         })
         .get(`/v0.1/apps/${testData.fakeNonExistentAppIdentifier}/deployments/${testData.fakeDeploymentName}/releases`)
         .reply((uri, requestBody) => {


### PR DESCRIPTION
Hi,

When running the `appcenter codepush deployment history Deployment --app Org/App` command when Org/App exists but does not have a deployment called "Deployment" I get the following error output:

```sh
{"succeeded":false,"errorCode":6,"errorMessage":"The app Org/App does not exist. Please double check the name, and provide it in the form owner/appname. \nRun the command \u001b[1mappcenter apps list\u001b[22m to see what apps you have access to."}
``` 

This error message is misleading since it tells the user that the app does not exist, and in this case it's the deployment that does not exist. 

I ran the command with the `--debug` flag to understand what result was returned from the backend, and I got this output:

```sh
Using appcenter-cli version: 2.11.0
logFilter, request: {
  "rawResponse": false,
  "queryString": {},
  "url": "https://api.appcenter.ms/v0.1/apps/Org/App/deployments/Deployment/releases",
  "method": "GET",
  "headers": {
    "Content-Type": "application/json; charset=utf-8",
    "user-agent": "appcenterCli/2.11.0 NodeJS/v18.6.0 darwin/21.6.0",
    "x-api-token": "xxx",
    "internal-request-source": "cli",
    "diagnostic-context": "xxx",
    "cli-command-name": "codepush deployment history"
  },
  "body": null
}
Response status code: 404
Body: Deployment "Deployment" does not exist.
```

It looks like this API now returns a `404` code instead of a `400` previously.

I opened this PR in the case this API change is made to last, but I think it might actually make more sense to change the API response to return a `400` as before so this issue is fixed for all users.