### PR TITLE
fix: iOS hermes detection

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -501,7 +501,7 @@ export function getiOSHermesEnabled(podFile: string): boolean {
 
   try {
     const podFileContents = fs.readFileSync(podPath).toString();
-    return /^([^#\n]*:?hermes_enabled(\s+|\n+)?(=>|:)(\s+|\n+)?true)$/.test(podFileContents);
+    return /([^#\n]*:?hermes_enabled(\s+|\n+)?(=>|:)(\s+|\n+)?true)/.test(podFileContents);
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
The original regex fails to match to [RN's default template](https://github.com/facebook/react-native/blob/0.67-stable/template/ios/Podfile).

```tsx
const t = `
require_relative '../node_modules/react-native/scripts/react_native_pods'
require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'

platform :ios, '11.0'

target 'HelloWorld' do
  config = use_native_modules!

  use_react_native!(
    :path => config[:reactNativePath],
    # to enable hermes on iOS, change \`false\` to \`true\` and then install pods
    :hermes_enabled => true
  )

  target 'HelloWorldTests' do
    inherit! :complete
    # Pods for testing
  end

  # Enables Flipper.
  #
  # Note that if you have use_frameworks! enabled, Flipper will not work and
  # you should disable the next line.
  use_flipper!()

  post_install do |installer|
    react_native_post_install(installer)
    __apply_Xcode_12_5_M1_post_install_workaround(installer)
  end
end
`;

// old one
console.log(/^([^#\n]*:?hermes_enabled(\s+|\n+)?(=>|:)(\s+|\n+)?true)$/.test(t));

// fixed one
console.log(/([^#\n]*:?hermes_enabled(\s+|\n+)?(=>|:)(\s+|\n+)?true)/.test(t));
```

Possible related issues:
https://github.com/microsoft/react-native-code-push/issues/2342
https://github.com/microsoft/react-native-code-push/issues/2346