### PR TITLE
[appcenter-file-upload-client-node] bump version to 1.2.7

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcenter-file-upload-client-node",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "3.0.0",

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "File Uploader Client for Node",
   "homepage": "https://github.com/microsoft/appcenter-cli",
   "author": "Microsoft",


### PR DESCRIPTION
This PR bumps the version of `appcenter-file-upload-client-node` to `1.2.7` in order to include package update changes.