### PR TITLE
fix(rnutils): fixed hermes path

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -541,7 +541,8 @@ async function getHermesCommand(gradleFile: string): Promise<string> {
     }
   };
   // Hermes is bundled with react-native since 0.69
-  const bundledHermesEngine = path.join("node_modules", "react-native", "sdks", "hermesc", getHermesOSBin(), getHermesOSExe());
+  const reactNativePath = path.dirname(require.resolve('react-native'));
+  const bundledHermesEngine = path.join(reactNativePath, 'sdks', 'hermesc', getHermesOSBin(), getHermesOSExe());
   if (fileExists(bundledHermesEngine)) {
     return bundledHermesEngine;
   }


### PR DESCRIPTION
Hi!

I've stumbled upon an issue where the hermesCommand wouldn't work with the `appcenter codepush release-react` command.
Our project is setup in a monorepo which causes this line to fail https://github.com/microsoft/appcenter-cli/blob/6c4e476a24280146750c1eea75bb5e933cf6c127/src/commands/codepush/lib/react-native-utils.ts#L545

And the way our build.gradle is setup also caused errors in https://github.com/microsoft/appcenter-cli/blob/6c4e476a24280146750c1eea75bb5e933cf6c127/src/commands/codepush/lib/react-native-utils.ts#L550
Since we used gradle variables there which aren't supported in the react-native-utils since they don't get parsed properly

Anyway, I fixed the first issue with a simple require and path.dirname so it always links to the proper react-native path even though there is a monorepo setup or something alike.