### PR TITLE
Fix autogenerating XamarinUITest project

### DIFF
--- a/src/commands/test/generate/uitest.ts
+++ b/src/commands/test/generate/uitest.ts
@@ -16,7 +16,6 @@ export default class GenerateUITestCommand extends GenerateCommand {
 
   protected async processTemplate(): Promise<void> {
     const platform = this.isIOS() ? "iOS" : "Android";
-    const packageFilePath = path.join(this.outputPath, `AppCenter.UITest.${platform}/packages.config`);
     const projectFilePath = path.join(this.outputPath, `AppCenter.UITest.${platform}/AppCenter.UITest.${platform}.csproj`);
 
     let latestVersion: string;
@@ -29,11 +28,12 @@ export default class GenerateUITestCommand extends GenerateCommand {
     }
 
     try {
-      // Replace version inside packages.config file
-      await this.replaceVersionInFile(packageFilePath, /(id="Xamarin\.UITest" version=")(\d+(\.\d+)+)/, latestVersion);
-
       // Replace version inside *.csproj file
-      await this.replaceVersionInFile(projectFilePath, /(packages\\Xamarin\.UITest\.)(\d+(\.\d+)+)/, latestVersion);
+      await this.replaceVersionInFile(
+        projectFilePath,
+        /(<PackageReference Include="Xamarin\.UITest" Version=")(\d+(\.\d+)+)/,
+        latestVersion
+      );
     } catch (e) {
       await this.copyTemplates();
       console.warn("Can't update UITest version. Using default templates. Details: " + e);

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
@@ -27,6 +27,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Xamarin.UITest" Version="4.0.1" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{845DEB90-8D90-47F6-9DAA-F07E68DCE9CF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>AppCenter.UITest.Android</RootNamespace>
     <AssemblyName>AppCenter.UITest.Android</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>10.0</LangVersion>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,20 +26,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.3.2.2\lib\net45\Xamarin.UITest.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Xamarin.UITest" Version="4.0.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Tests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/packages.config
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="3.2.2" targetFramework="net45" />
-</packages>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
@@ -1,14 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{764CE893-AF50-456A-8263-2675A94D96DF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>AppCenter.UITest.iOS</RootNamespace>
     <AssemblyName>AppCenter.UITest.iOS</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>10.0</LangVersion>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,20 +26,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="Xamarin.UITest">
-      <HintPath>..\packages\Xamarin.UITest.3.2.2\lib\net45\Xamarin.UITest.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
-    </Reference>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Xamarin.UITest" Version="4.0.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Tests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
@@ -27,6 +27,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Xamarin.UITest" Version="4.0.1" />
+    <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
   </ItemGroup>
 </Project>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/packages.config
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="Xamarin.UITest" version="3.2.2" targetFramework="net45" />
-</packages>

--- a/test/commands/test/generate/uitest-test.ts
+++ b/test/commands/test/generate/uitest-test.ts
@@ -83,7 +83,7 @@ describe("Validating UITest template generation", () => {
   });
 
   it("should not touch NuGet version on failure", async () => {
-    const latestVersion = "3.13.3";
+    const latestVersion = "4.1.0";
     // Arrange
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],

--- a/test/commands/test/generate/uitest-test.ts
+++ b/test/commands/test/generate/uitest-test.ts
@@ -45,14 +45,12 @@ describe("Validating UITest template generation", () => {
       )
     ).to.be.true;
     expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/Tests.cs`))).to.be.true;
-    expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`))).to.be.true;
     expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/Properties/AssemblyInfo.cs`))).to.be
       .true;
   });
 
   it("should update NuGet version", async () => {
     // Arrange
-    const fakeLatestVersion = "2.5.6";
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],
       commandPath: "Test",
@@ -66,7 +64,10 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
+    const packageFilePath = path.join(
+      command.outputPath,
+      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
+    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
@@ -105,7 +106,10 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
+    const packageFilePath = path.join(
+      command.outputPath,
+      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
+    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
@@ -155,7 +159,10 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
+    const packageFilePath = path.join(
+      command.outputPath,
+      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
+    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`

--- a/test/commands/test/generate/uitest-test.ts
+++ b/test/commands/test/generate/uitest-test.ts
@@ -50,6 +50,7 @@ describe("Validating UITest template generation", () => {
   });
 
   it("should update NuGet version", async () => {
+    const fakeLatestVersion = "3.14.0";
     // Arrange
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],
@@ -64,19 +65,12 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(
-      command.outputPath,
-      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
-    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
-    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).not.contain(fakeLatestVersion);
-
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
 
@@ -84,14 +78,12 @@ describe("Validating UITest template generation", () => {
     await (command as any).processTemplate();
 
     // Assert
-    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).contain(fakeLatestVersion);
-
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).contain(fakeLatestVersion);
   });
 
   it("should not touch NuGet version on failure", async () => {
+    const latestVersion = "3.13.3";
     // Arrange
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],
@@ -106,31 +98,21 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(
-      command.outputPath,
-      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
-    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
-    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).contain("3.2.2");
-
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
-    expect(projectFileContent).contain("3.2.2");
+    expect(projectFileContent).contain(latestVersion);
 
     // Act
     await (command as any).processTemplate();
 
     // Assert
-    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).contain("3.2.2");
-
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
-    expect(projectFileContent).contain("3.2.2");
+    expect(projectFileContent).contain(latestVersion);
   });
 
   it("should recover original template files on failure", async () => {
@@ -159,19 +141,12 @@ describe("Validating UITest template generation", () => {
       });
     });
 
-    const packageFilePath = path.join(
-      command.outputPath,
-      `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
-    );
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
-    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).not.contain(fakeLatestVersion);
-
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
 
@@ -179,9 +154,6 @@ describe("Validating UITest template generation", () => {
     await (command as any).processTemplate();
 
     // Assert
-    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
-    expect(packageFileContent).not.contain(fakeLatestVersion);
-
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
   });


### PR DESCRIPTION
This PR fixing autogenerating `XamarinUITes`t Project, added support of `.NET6`, changed test for this.