### PR TITLE
Update jszip to 3.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "inquirer": "8.2.0",
         "iso8601-duration": "1.3.0",
         "jsonwebtoken": "9.0.0",
-        "jszip": "3.7.1",
+        "jszip": "3.8.0",
         "lodash": "4.17.21",
         "minimist": "1.2.6",
         "mkdirp": "1.0.4",
@@ -6752,9 +6752,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.8.0.tgz",
+      "integrity": "sha512-cnpQrXvFSLdsR9KR5/x7zdf6c3m8IhZfZzSblFEHSqBaVwD2nvJ4CuCKLyvKvwBgZm08CgfSoiTBQLm5WW9hGw==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -17786,9 +17786,9 @@
       }
     },
     "jszip": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.8.0.tgz",
+      "integrity": "sha512-cnpQrXvFSLdsR9KR5/x7zdf6c3m8IhZfZzSblFEHSqBaVwD2nvJ4CuCKLyvKvwBgZm08CgfSoiTBQLm5WW9hGw==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "inquirer": "8.2.0",
     "iso8601-duration": "1.3.0",
     "jsonwebtoken": "9.0.0",
-    "jszip": "3.7.1",
+    "jszip": "3.8.0",
     "lodash": "4.17.21",
     "minimist": "1.2.6",
     "mkdirp": "1.0.4",


### PR DESCRIPTION
Fixes WS-2023-0004 zip-slip vulnerability.

[AB#98058](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/98058)