### PR TITLE
[Codepush][Hermes] Fixing compose-source-maps command calls

### DIFF
--- a/src/commands/codepush/lib/react-native-utils.ts
+++ b/src/commands/codepush/lib/react-native-utils.ts
@@ -419,12 +419,12 @@ export async function runHermesEmitBinaryCommand(
     }
 
     return new Promise((resolve, reject) => {
-      const composeSourceMapsArgs = [sourcemapOutput, jsCompilerSourceMapFile, "-o", sourcemapOutput];
+      const composeSourceMapsArgs = [composeSourceMapsPath, sourcemapOutput, jsCompilerSourceMapFile, "-o", sourcemapOutput];
 
       // https://github.com/facebook/react-native/blob/master/react.gradle#L211
       // https://github.com/facebook/react-native/blob/master/scripts/react-native-xcode.sh#L178
       // packager.sourcemap.map + hbc.sourcemap.map = sourcemap.map
-      const composeSourceMapsProcess = childProcess.spawn(composeSourceMapsPath, composeSourceMapsArgs);
+      const composeSourceMapsProcess = childProcess.spawn("node", composeSourceMapsArgs);
       out.text(`${composeSourceMapsPath} ${composeSourceMapsArgs.join(" ")}`);
 
       composeSourceMapsProcess.stdout.on("data", (data: Buffer) => {


### PR DESCRIPTION
Currently when pushing codepush update with hermes enabled it calls file `compose-source-maps.js` directly, problem will arise when you call js file directly on windows it will causing exception and causing failed to release codepush update. Instead calling `compose-source-maps.js` I think it's better to call with node command