### PR TITLE
 Fix merge-junit-xml and merge-nunit-xml issue

### DIFF
--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -59,7 +59,7 @@ export default class RunAppiumTestsCommand extends RunTestsDownloadResultCommand
       throw new Error(`Couldn't merge xml test results to ${this.mergeJUnitXml}`);
     }
 
-        const strXml: string = new XMLSerializer().serializeToString(xml);
-        return pfs.writeFile(path.join(reportPath, this.mergeJUnitXml), strXml);
+    const strXml: string = new XMLSerializer().serializeToString(xml);
+    return pfs.writeFile(path.join(reportPath, this.mergeJUnitXml), strXml);
   }
 }

--- a/src/commands/test/run/appium.ts
+++ b/src/commands/test/run/appium.ts
@@ -4,6 +4,7 @@ import { generateAbsolutePath } from "../../../util/misc/fs-helper";
 import { CommandArgs, help, longName, hasArg, required } from "../../../util/commandline";
 import { AppiumPreparer } from "../lib/appium-preparer";
 import { Messages } from "../lib/help-messages";
+import { XMLSerializer } from "@xmldom/xmldom";
 import { JUnitXmlUtil } from "../lib/junit-xml-util";
 import { RunTestsDownloadResultCommand } from "../lib/run-tests-download-result-command";
 
@@ -58,6 +59,7 @@ export default class RunAppiumTestsCommand extends RunTestsDownloadResultCommand
       throw new Error(`Couldn't merge xml test results to ${this.mergeJUnitXml}`);
     }
 
-    return pfs.writeFile(path.join(reportPath, this.mergeJUnitXml), xml);
+        const strXml: string = new XMLSerializer().serializeToString(xml);
+        return pfs.writeFile(path.join(reportPath, this.mergeJUnitXml), strXml);
   }
 }

--- a/src/commands/test/run/manifest.ts
+++ b/src/commands/test/run/manifest.ts
@@ -2,6 +2,7 @@ import { CommandArgs, help, longName, required, hasArg } from "../../../util/com
 import { Messages } from "../lib/help-messages";
 import * as path from "path";
 import { writeFile, walk } from "../../../util/misc/promisfied-fs";
+import { XMLSerializer } from "@xmldom/xmldom";
 import { XmlUtil } from "../lib/xml-util";
 import { XmlUtilBuilder } from "../lib/xml-util-builder";
 import { generateAbsolutePath } from "../../../util/misc/fs-helper";
@@ -65,6 +66,7 @@ export default class RunManifestTestsCommand extends RunTestsDownloadResultComma
       throw new Error("XML merging has ended with an error");
     }
 
-    await writeFile(path.join(outputDir, this.outputXmlName), xml);
+    const strXml: string = new XMLSerializer().serializeToString(xml);
+    await writeFile(path.join(outputDir, this.outputXmlName), strXml);
   }
 }


### PR DESCRIPTION
Using the option  --merged-file-name "output.xml" --test-output-dir JunitTestResult, facing the below issue.

Same for --merge-junit-xml  "output.xml" --test-output-dir JunitTestResult

i can see .zip was was downloaded but merged files is not working!

Downloaded artifacts to JunitTestResult\junit_xml_zip.zip 

Error: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Document

Similar issue with nunit for xamarin uitest: https://github.com/microsoft/appcenter-cli/pull/1814