### PR TITLE
Revert generated project and hardcode version of X.UITest

### DIFF
--- a/src/commands/test/generate/uitest.ts
+++ b/src/commands/test/generate/uitest.ts
@@ -22,7 +22,14 @@ export default class GenerateUITestCommand extends GenerateCommand {
     let latestVersion: string;
 
     try {
-      latestVersion = await this.getLatestUITestVersionNumber();
+      // Using hardcoded version because starting from version 4.* Xamarin.UITest drops framework v4.5.
+      // Using latest version of Xamarin.UITest requires to update the generated project (see https://github.com/microsoft/appcenter-cli/pull/2179).
+      // However, it will also require us to update the backend side of the Build service,
+      // so the generated project would be built using newer msbuild tool (currently it is msbuild 14, see https://dev.azure.com/msmobilecenter/Mobile-Center/_git/appcenter/pullrequest/55845).
+      // The mentioned PR in build service doesn't work, so we need to debug it to make the msbuild udpated properly.
+      // Until then, we are using a hardcoded working version of Xamarin.UITest.
+
+      latestVersion = "3.2.9"; // await this.getLatestUITestVersionNumber();
     } catch (e) {
       console.warn("Can't retrieve latest UITest version. Using default version from template. Details: " + e);
       return;

--- a/src/commands/test/generate/uitest.ts
+++ b/src/commands/test/generate/uitest.ts
@@ -16,6 +16,7 @@ export default class GenerateUITestCommand extends GenerateCommand {
 
   protected async processTemplate(): Promise<void> {
     const platform = this.isIOS() ? "iOS" : "Android";
+    const packageFilePath = path.join(this.outputPath, `AppCenter.UITest.${platform}/packages.config`);
     const projectFilePath = path.join(this.outputPath, `AppCenter.UITest.${platform}/AppCenter.UITest.${platform}.csproj`);
 
     let latestVersion: string;
@@ -28,12 +29,11 @@ export default class GenerateUITestCommand extends GenerateCommand {
     }
 
     try {
+      // Replace version inside packages.config file
+      await this.replaceVersionInFile(packageFilePath, /(id="Xamarin\.UITest" version=")(\d+(\.\d+)+)/, latestVersion);
+
       // Replace version inside *.csproj file
-      await this.replaceVersionInFile(
-        projectFilePath,
-        /(<PackageReference Include="Xamarin\.UITest" Version=")(\d+(\.\d+)+)/,
-        latestVersion
-      );
+      await this.replaceVersionInFile(projectFilePath, /(packages\\Xamarin\.UITest\.)(\d+(\.\d+)+)/, latestVersion);
     } catch (e) {
       await this.copyTemplates();
       console.warn("Can't update UITest version. Using default templates. Details: " + e);

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
@@ -26,8 +26,6 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
   </ItemGroup>

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/AppCenter.UITest.Android.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{845DEB90-8D90-47F6-9DAA-F07E68DCE9CF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>AppCenter.UITest.Android</RootNamespace>
     <AssemblyName>AppCenter.UITest.Android</AssemblyName>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10.0</LangVersion>
-    <Deterministic>false</Deterministic>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,7 +28,20 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
+    <Reference Include="System" />
+    <Reference Include="Xamarin.UITest">
+      <HintPath>..\packages\Xamarin.UITest.3.2.2\lib\net45\Xamarin.UITest.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/packages.config
+++ b/src/commands/test/lib/templates/uitest/android/AppCenter.UITest.Android/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.12.0" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="3.2.2" targetFramework="net45" />
+</packages>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
@@ -26,8 +26,6 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
   </ItemGroup>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/AppCenter.UITest.iOS.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{764CE893-AF50-456A-8263-2675A94D96DF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>AppCenter.UITest.iOS</RootNamespace>
     <AssemblyName>AppCenter.UITest.iOS</AssemblyName>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10.0</LangVersion>
-    <Deterministic>false</Deterministic>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,7 +28,20 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Xamarin.UITest" Version="4.1.0" />
+    <Reference Include="System" />
+    <Reference Include="Xamarin.UITest">
+      <HintPath>..\packages\Xamarin.UITest.3.2.2\lib\net45\Xamarin.UITest.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/packages.config
+++ b/src/commands/test/lib/templates/uitest/ios/AppCenter.UITest.iOS/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.12.0" targetFramework="net45" />
+  <package id="Xamarin.UITest" version="3.2.2" targetFramework="net45" />
+</packages>

--- a/test/commands/test/generate/uitest-test.ts
+++ b/test/commands/test/generate/uitest-test.ts
@@ -45,13 +45,14 @@ describe("Validating UITest template generation", () => {
       )
     ).to.be.true;
     expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/Tests.cs`))).to.be.true;
+    expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`))).to.be.true;
     expect(await pfs.exists(path.join(command.outputPath, `AppCenter.UITest.${command.platform}/Properties/AssemblyInfo.cs`))).to.be
       .true;
   });
 
   it("should update NuGet version", async () => {
-    const fakeLatestVersion = "3.14.0";
     // Arrange
+    const fakeLatestVersion = "2.5.6";
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],
       commandPath: "Test",
@@ -65,12 +66,16 @@ describe("Validating UITest template generation", () => {
       });
     });
 
+    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
+    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).not.contain(fakeLatestVersion);
+
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
 
@@ -78,12 +83,14 @@ describe("Validating UITest template generation", () => {
     await (command as any).processTemplate();
 
     // Assert
+    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).contain(fakeLatestVersion);
+
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).contain(fakeLatestVersion);
   });
 
   it("should not touch NuGet version on failure", async () => {
-    const latestVersion = "4.1.0";
     // Arrange
     const args: CommandArgs = {
       command: ["test", "generate", "uitest"],
@@ -98,21 +105,28 @@ describe("Validating UITest template generation", () => {
       });
     });
 
+    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
+    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).contain("3.2.2");
+
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
-    expect(projectFileContent).contain(latestVersion);
+    expect(projectFileContent).contain("3.2.2");
 
     // Act
     await (command as any).processTemplate();
 
     // Assert
+    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).contain("3.2.2");
+
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
-    expect(projectFileContent).contain(latestVersion);
+    expect(projectFileContent).contain("3.2.2");
   });
 
   it("should recover original template files on failure", async () => {
@@ -141,12 +155,16 @@ describe("Validating UITest template generation", () => {
       });
     });
 
+    const packageFilePath = path.join(command.outputPath, `AppCenter.UITest.${command.platform}/packages.config`);
     const projectFilePath = path.join(
       command.outputPath,
       `AppCenter.UITest.${command.platform}/AppCenter.UITest.${command.platform}.csproj`
     );
 
     // Assert
+    let packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).not.contain(fakeLatestVersion);
+
     let projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
 
@@ -154,6 +172,9 @@ describe("Validating UITest template generation", () => {
     await (command as any).processTemplate();
 
     // Assert
+    packageFileContent = await pfs.readFile(packageFilePath, "utf8");
+    expect(packageFileContent).not.contain(fakeLatestVersion);
+
     projectFileContent = await pfs.readFile(projectFilePath, "utf8");
     expect(projectFileContent).not.contain(fakeLatestVersion);
   });


### PR DESCRIPTION
This PR reverts changes done to the generated test project earlier because it now breaks the build on the backend side. Until we fix the backend build tooling, we need to revert this change and hardcode the specific version of Xamarin.UItest framework, so the "Test on a real device" step would work.