### PR TITLE
feat: added additional option to disable nested api cals when getting list of deployments

### DIFF
--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -27,6 +27,11 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
   @longName("displayKeys")
   public displayKeys: boolean;
 
+  @help("Specifies whether to Fetch Deployment Metric or Not")
+  @shortName("m")
+  @longName("disableDeploymentMetric")
+  public disableDeploymentMetric: boolean;
+
   constructor(args: CommandArgs) {
     super(args);
   }
@@ -107,7 +112,11 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
   }
 
   private async generateMetricsJSON(deployment: models.Deployment, client: AppCenterClient): Promise<models.CodePushReleaseMetric> {
-    const metrics: models.CodePushReleaseMetric[] = await this.getMetrics(deployment, client);
+    let metrics: models.CodePushReleaseMetric[] = [];
+    if (!this.disableDeploymentMetric) {
+      out.text("Note: To Disbale Deployment Metrics Info set -m | --disableDeploymentMetric option to true");
+      metrics = await this.getMetrics(deployment, client);
+    }
 
     if (metrics.length) {
       let releasesTotalActive: number = 0;

--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -96,7 +96,7 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
 
           const metricsJSON: models.CodePushReleaseMetric = await this.generateMetricsJSON(deployment, client);
 
-          if (metricsJSON && deployment.latestRelease) {
+          if (metricsJSON) {
             deployment.latestRelease.metrics = metricsJSON;
           }
 

--- a/src/commands/codepush/deployment/list.ts
+++ b/src/commands/codepush/deployment/list.ts
@@ -90,6 +90,10 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
       deployments,
       async (deployment) => {
         if (formatIsJson()) {
+          if (!deployment.latestRelease || this.skipFetchingDeploymentMetrics) {
+            return deployment;
+          }
+
           const metricsJSON: models.CodePushReleaseMetric = await this.generateMetricsJSON(deployment, client);
 
           if (metricsJSON && deployment.latestRelease) {
@@ -104,7 +108,7 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
 
         if (deployment.latestRelease) {
           metadataString = this.generateMetadataString(deployment.latestRelease);
-          metricsString = await this.getMetricsString(deployment, client);
+          metricsString = this.skipFetchingDeploymentMetrics ? "" : await this.getMetricsString(deployment, client);
         } else {
           metadataString = chalk.magenta("No updates released");
           metricsString = chalk.magenta("No installs recorded");
@@ -117,9 +121,6 @@ export default class CodePushDeploymentListListCommand extends AppCommand {
   }
 
   private async generateMetricsJSON(deployment: models.Deployment, client: AppCenterClient): Promise<models.CodePushReleaseMetric> {
-    if (this.skipFetchingDeploymentMetrics) {
-      return null;
-    }
     const metrics: models.CodePushReleaseMetric[] = await this.getMetrics(deployment, client);
 
     if (metrics.length) {


### PR DESCRIPTION
## [Issue](https://github.com/microsoft/appcenter-cli/issues/2286)
When getting the list of deployments from appcenter the command failed with an error message that failed to get deployments .
<img width="823" alt="image" src="https://user-images.githubusercontent.com/32166676/232409485-bf2c7ce1-5992-4060-8883-4d0dc6b8474c.png">

## Reason
This is happening because of the nested calls the appcenter-cli does to fetch metrics for each deployment if you have a considerable deployment list then the nested calls to fetch metric info of each deployment exceeds the API rate limiting due to which the command fails

## Fix
I have added another option to the list command which disables nested API calls for metric info.
<img width="998" alt="image" src="https://user-images.githubusercontent.com/32166676/232412896-2ae1ff2e-e34c-403f-b2a3-fe63f1662f7d.png">

