### PR TITLE
Version 2.13.6 for appcenter-cli and Version 1.2.9 for appcenter-file-upload-client node

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -3060,9 +3060,9 @@
       "dev": true
     },
     "node_modules/vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -5435,9 +5435,9 @@
       "dev": true
     },
     "vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcenter-file-upload-client-node",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "3.0.0",

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "File Uploader Client for Node",
   "homepage": "https://github.com/microsoft/appcenter-cli",
   "author": "Microsoft",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcenter-cli",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcenter-cli",
-      "version": "2.13.5",
+      "version": "2.13.6",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "0.8.6",
@@ -11959,9 +11959,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -21845,9 +21845,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-cli",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "Command line tool for Visual Studio App Center",
   "keywords": [
     "microsoft",


### PR DESCRIPTION
Bump VM2 package to fix vulnerability
AB#[100513](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/100513)