### PR TITLE
Allow deployment name to be a number

### DIFF
--- a/src/commands/codepush/deployment/add.ts
+++ b/src/commands/codepush/deployment/add.ts
@@ -38,7 +38,7 @@ export default class CodePushAddCommand extends AppCommand {
       const httpRequest = await out.progress(
         "Creating a new CodePush deployment...",
         clientRequest<models.Deployment>((cb) =>
-          client.codePushDeployments.create(app.ownerName, app.appName, this.newDeploymentName, cb)
+          client.codePushDeployments.create(app.ownerName, app.appName, this.newDeploymentName.toString(), cb)
         )
       );
       deployment = httpRequest.result;

--- a/src/commands/codepush/deployment/remove.ts
+++ b/src/commands/codepush/deployment/remove.ts
@@ -40,7 +40,7 @@ export default class CodePushRemoveDeploymentCommand extends AppCommand {
       debug("Removing CodePush deployment");
       await out.progress(
         `Removing CodePush deployment...`,
-        clientRequest((cb) => client.codePushDeployments.deleteMethod(this.deploymentName, app.ownerName, app.appName, cb))
+        clientRequest((cb) => client.codePushDeployments.deleteMethod(this.deploymentName.toString(), app.ownerName, app.appName, cb))
       );
     } catch (error) {
       debug(`Failed to remove CodePush deployment - ${inspect(error)}`);


### PR DESCRIPTION
Allow deployment name to be a number when invoking `appcenter codepush deployment add/remove`