### PR TITLE
Version 1.2.11 for appcenter-file-upload-client node

### DIFF
--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "appcenter-file-upload-client-node",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "3.0.0",

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appcenter-file-upload-client-node",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "File Uploader Client for Node",
   "homepage": "https://github.com/microsoft/appcenter-cli",
   "author": "Microsoft",


### PR DESCRIPTION
[AB#101802](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/101802)
- Fix CVE-2023-37466 in vm2 3.9.19. Severity: Critical
- Update Node version on Azure pipelines
- Update Typescript version for updated Proxy-Agent package