### PR TITLE
Bump NodeJS to 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ commands that they'd like to execute. You can currently login and view/configure
 
 ## Prerequisites
 
-The recommended Node.js version is 12 or higher, 
+The required Node.js version is 14 or higher, 
 Mono and the Android-SDK are required to run the UI test for Android and iOS.
 
 ## Installation

--- a/appcenter-file-upload-client-node/package-lock.json
+++ b/appcenter-file-upload-client-node/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/mocha": "9.0.0",
-        "@types/node": "12.x",
+        "@types/node": "14.x",
         "@types/uuid": "7.0.3",
         "@typescript-eslint/eslint-plugin": "4.0.0",
         "@typescript-eslint/parser": "3.10.1",
@@ -235,9 +235,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
-      "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==",
+      "version": "14.18.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
+      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -3190,9 +3190,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
-      "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==",
+      "version": "14.18.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
+      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
       "dev": true
     },
     "@types/uuid": {

--- a/appcenter-file-upload-client-node/package.json
+++ b/appcenter-file-upload-client-node/package.json
@@ -21,7 +21,7 @@
   "main": "out/index.js",
   "devDependencies": {
     "@types/mocha": "9.0.0",
-    "@types/node": "12.x",
+    "@types/node": "14.x",
     "@types/uuid": "7.0.3",
     "@typescript-eslint/eslint-plugin": "4.0.0",
     "@typescript-eslint/parser": "3.10.1",

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ local CI configurations).
 
 ## Technologies Used
 
-App Center cli is written using Node.js version 12 and [TypeScript](http://typescriptlang.org).
+App Center cli is written using Node.js version 14 and [TypeScript](http://typescriptlang.org).
 Wrappers over the App Center HTTP API are generated using the [AutoRest](https://github.com/Azure/autorest) code generator.
 And the usual plethora of npm modules.
 
@@ -18,7 +18,7 @@ is used to record and playback mock http traffic.
 
 ### Prerequisites
 
-Install the latest version of Node 12 from [here](https://nodejs.org). If you are on a Mac, we recommend
+Install the latest version of Node 14 from [here](https://nodejs.org). If you are on a Mac, we recommend
 a 64-bit version.
 
 Also have a working git installation. The code is available from this [repo](https://github.com/microsoft/appcenter-cli).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "homepage": "https://github.com/microsoft/appcenter-cli#readme",
   "engine": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
[AB#102566](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/SDK/Backlog%20Items/?workitem=102566)

Bump of minimal NodeJS version required by [PR#2387](https://github.com/microsoft/appcenter-cli/pull/2387) where fix https://github.com/advisories/GHSA-cchq-frgv-rjh5 in vm2 3.9.19. Severity: Critical has been implemented. 