### PR TITLE
fix(help): Release React command update `output-dir` help desc

### DIFF
--- a/src/commands/codepush/release-react.ts
+++ b/src/commands/codepush/release-react.ts
@@ -99,7 +99,7 @@ export default class CodePushReleaseReactCommand extends CodePushReleaseCommandB
   @hasArg
   public sourcemapOutputDir: string;
 
-  @help("Path to where the bundle and sourcemap should be written. If omitted, a bundle and sourcemap will not be written")
+  @help("Path to where the bundle should be written. If omitted, the bundle will not be saved on your machine")
   @shortName("o")
   @longName("output-dir")
   @hasArg


### PR DESCRIPTION
Update the command description to reflect the latest state of the code.

`output-dir` has no effect on the generated source maps destination.