### PR TITLE
Update ms-rest-js to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@azure/core-client": "^1.7.2",
         "@azure/core-rest-pipeline": "^1.10.3",
-        "@azure/ms-rest-js": "^2.6.6",
+        "@azure/ms-rest-js": "^2.7.0",
         "@azure/storage-blob": "^12.14.0",
         "@xmldom/xmldom": "0.8.7",
         "abort-controller": "3.0.0",
@@ -348,14 +348,14 @@
       }
     },
     "node_modules/@azure/ms-rest-js": {
-      "version": "2.6.6",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz",
+      "integrity": "sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==",
       "dependencies": {
         "@azure/core-auth": "^1.1.4",
         "abort-controller": "^3.0.0",
         "form-data": "^2.5.0",
         "node-fetch": "^2.6.7",
-        "tough-cookie": "^3.0.1",
         "tslib": "^1.10.0",
         "tunnel": "0.0.6",
         "uuid": "^8.3.2",
@@ -372,18 +372,6 @@
       },
       "engines": {
         "node": ">= 0.12"
-      }
-    },
-    "node_modules/@azure/ms-rest-js/node_modules/tough-cookie": {
-      "version": "3.0.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@azure/ms-rest-js/node_modules/tslib": {
@@ -5366,13 +5354,6 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-absolute": {
       "version": "1.0.0",
       "dev": true,
@@ -7822,10 +7803,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -7845,6 +7822,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10800,13 +10778,14 @@
       }
     },
     "@azure/ms-rest-js": {
-      "version": "2.6.6",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz",
+      "integrity": "sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==",
       "requires": {
         "@azure/core-auth": "^1.1.4",
         "abort-controller": "^3.0.0",
         "form-data": "^2.5.0",
         "node-fetch": "^2.6.7",
-        "tough-cookie": "^3.0.1",
         "tslib": "^1.10.0",
         "tunnel": "0.0.6",
         "uuid": "^8.3.2",
@@ -10819,14 +10798,6 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
-          }
-        },
-        "tough-cookie": {
-          "version": "3.0.1",
-          "requires": {
-            "ip-regex": "^2.1.0",
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
           }
         },
         "tslib": {
@@ -14159,9 +14130,6 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
       "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
-    "ip-regex": {
-      "version": "2.1.0"
-    },
     "is-absolute": {
       "version": "1.0.0",
       "dev": true,
@@ -15742,9 +15710,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "psl": {
-      "version": "1.8.0"
-    },
     "pump": {
       "version": "3.0.0",
       "requires": {
@@ -15761,7 +15726,8 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "pupa": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "dependencies": {
     "@azure/core-client": "^1.7.2",
     "@azure/core-rest-pipeline": "^1.10.3",
-    "@azure/ms-rest-js": "^2.6.6",
+    "@azure/ms-rest-js": "^2.7.0",
     "@azure/storage-blob": "^12.14.0",
     "@xmldom/xmldom": "0.8.7",
     "abort-controller": "3.0.0",


### PR DESCRIPTION
Updating ms-rest-js to v2.7.0 removes punycode from appcenter-cli's dependencies.

https://github.com/microsoft/appcenter-cli/issues/2470/
[AB#104031](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/104031)