### PR TITLE
Add explicit version for appcenter-file-upload-client-node to 1.2.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@xmldom/xmldom": "0.8.7",
         "abort-controller": "3.0.0",
         "appcenter-file-upload-client": "0.1.0",
-        "appcenter-file-upload-client-node": "^1.2.11",
+        "appcenter-file-upload-client-node": "1.2.12",
         "bplist": "0.0.4",
         "chalk": "4.1.2",
         "cli-spinner": "0.2.10",
@@ -1796,9 +1796,9 @@
       }
     },
     "node_modules/appcenter-file-upload-client-node": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.11.tgz",
-      "integrity": "sha512-xIQ3qXmNFLOR0cZscNoLnprxOIF/CmHV5kKkk9l12dOfv/9xH4OAgj/D3qwC3+iS/OnvV1bn2KLdfH7WHag6sQ==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.12.tgz",
+      "integrity": "sha512-ZfO9OaTzGQisNeF1kSZ5i7EBo8Q3Bj+TvguOEWsD3cWAr+KK8nYGwGF1dDTQYCVBJSC6JeO9FxqwqhGliCi/GQ==",
       "dependencies": {
         "abort-controller": "3.0.0",
         "node-fetch": "~2.6.7",
@@ -12412,9 +12412,9 @@
       }
     },
     "appcenter-file-upload-client-node": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.11.tgz",
-      "integrity": "sha512-xIQ3qXmNFLOR0cZscNoLnprxOIF/CmHV5kKkk9l12dOfv/9xH4OAgj/D3qwC3+iS/OnvV1bn2KLdfH7WHag6sQ==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/appcenter-file-upload-client-node/-/appcenter-file-upload-client-node-1.2.12.tgz",
+      "integrity": "sha512-ZfO9OaTzGQisNeF1kSZ5i7EBo8Q3Bj+TvguOEWsD3cWAr+KK8nYGwGF1dDTQYCVBJSC6JeO9FxqwqhGliCi/GQ==",
       "requires": {
         "abort-controller": "3.0.0",
         "node-fetch": "~2.6.7",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@xmldom/xmldom": "0.8.7",
     "abort-controller": "3.0.0",
     "appcenter-file-upload-client": "0.1.0",
-    "appcenter-file-upload-client-node": "^1.2.11",
+    "appcenter-file-upload-client-node": "1.2.12",
     "bplist": "0.0.4",
     "chalk": "4.1.2",
     "cli-spinner": "0.2.10",


### PR DESCRIPTION
Add explicit version for appcenter-file-upload-client-node to 1.2.12