### PR TITLE
Fix delete app command params order

### DIFF
--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -16,7 +16,7 @@ export default class AppDeleteCommand extends AppCommand {
 
     if (confirmation) {
       try {
-        await out.progress("Deleting app ...", client.apps.delete(app.ownerName, app.appName));
+        await out.progress("Deleting app ...", client.apps.delete(app.appName, app.ownerName));
       } catch (error) {
         const statusCode = error.response.status;
         if (statusCode >= 400) {


### PR DESCRIPTION
Currently delete app command doesn't work since appcenter-cli sends delete request with wrong order of params with this PR this should be fixed

[AB#107373](https://dev.azure.com/msmobilecenter/Mobile-Center/_boards/board/t/Mobile%20SDK%20team/Backlog%20Items/?workitem=107373)