### PR TITLE
Fix Apache Commons IO high severity vulnerability

### DIFF
--- a/src/commands/test/lib/templates/appium/android/pom.xml
+++ b/src/commands/test/lib/templates/appium/android/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.xamarin.samples.appium</groupId>
@@ -41,10 +41,15 @@
       <version>5.3.39</version>
     </dependency>
     <dependency>
-    <groupId>org.springframework</groupId>
-    <artifactId>spring-context</artifactId>
-    <version>5.3.39</version>
-  </dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>5.3.39</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.14.0</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/commands/test/lib/templates/appium/ios/pom.xml
+++ b/src/commands/test/lib/templates/appium/ios/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.xamarin.samples.appium</groupId>
@@ -41,9 +41,14 @@
       <version>5.3.39</version>
     </dependency>
     <dependency>
-    <groupId>org.springframework</groupId>
-    <artifactId>spring-context</artifactId>
-    <version>5.3.39</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>5.3.39</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.14.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Description
> This issue affects Apache Commons IO: from 2.0 before 2.14.0.
> Users are recommended to upgrade to version 2.14.0 or later, which fixes the issue.

Current commons-io version: 2.11.0
Updated commons-io version: 2.14.0

More details https://github.com/advisories/GHSA-78wr-2p64-hpwj
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1546106&view=results)
## Related PRs or issues
[#AB107782](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/107782)
